### PR TITLE
feat: Add healthchecks to docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U opencut"]
+      test: ["CMD", "pg_isready -U opencut"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,17 +10,38 @@ services:
       - postgres_data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U opencut"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
+
   redis:
     image: redis
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
+
   serverless-redis-http:
+    image: hiett/serverless-redis-http:latest
     ports:
       - "8079:80"
-    image: hiett/serverless-redis-http:latest
     environment:
       SRH_MODE: env
       SRH_TOKEN: example_token
       SRH_CONNECTION_STRING: "redis://redis:6379"
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1:80 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
+
 volumes:
   postgres_data:


### PR DESCRIPTION
Added health checks for all services in the Docker Compose file. 

This will help make sure the app starts only after its dependencies are ready (once we add the app service later). 

For now, if a health check fails, the services won’t start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added health checks to database, Redis, and serverless Redis services to improve service readiness monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->