### PR TITLE
fix: correct auth route paths to match (auth) folder structure

### DIFF
--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -77,14 +77,21 @@ function LoginForm() {
         size="lg"
         disabled={isAnyLoading}
       >
-        {isGoogleLoading ? <Loader2 className="animate-spin" /> : (<GoogleIcon />)} Continue with Google
+        {isGoogleLoading ? (
+          <Loader2 className="animate-spin" />
+        ) : (
+          <GoogleIcon />
+        )}{" "}
+        Continue with Google
       </Button>
       <div className="relative">
         <div className="absolute inset-0 flex items-center">
           <Separator className="w-full" />
         </div>
         <div className="relative flex justify-center text-xs uppercase">
-          <span className="bg-background px-2 text-muted-foreground">Or continue with</span>
+          <span className="bg-background px-2 text-muted-foreground">
+            Or continue with
+          </span>
         </div>
       </div>
       <div className="space-y-4">
@@ -144,14 +151,21 @@ export default function LoginPage() {
           </CardDescription>
         </CardHeader>
         <CardContent className="pt-0">
-          <Suspense fallback={<div className="text-center">
-            <Loader2 className="animate-spin" />
-          </div>}>
+          <Suspense
+            fallback={
+              <div className="text-center">
+                <Loader2 className="animate-spin" />
+              </div>
+            }
+          >
             <LoginForm />
           </Suspense>
           <div className="mt-6 text-center text-sm">
             Don't have an account?{" "}
-            <Link href="/auth/signup" className="font-medium text-primary underline-offset-4 hover:underline">
+            <Link
+              href="/signup"
+              className="font-medium text-primary underline-offset-4 hover:underline"
+            >
               Sign up
             </Link>
           </div>

--- a/apps/web/src/app/(auth)/signup/page.tsx
+++ b/apps/web/src/app/(auth)/signup/page.tsx
@@ -44,7 +44,7 @@ function SignUpForm() {
       return;
     }
 
-    router.push("/auth/login");
+    router.push("/login");
   };
 
   const handleGoogleSignUp = async () => {
@@ -80,7 +80,12 @@ function SignUpForm() {
         size="lg"
         disabled={isAnyLoading}
       >
-        {isGoogleLoading ? <Loader2 className="animate-spin" /> : (<GoogleIcon />)} Continue with Google
+        {isGoogleLoading ? (
+          <Loader2 className="animate-spin" />
+        ) : (
+          <GoogleIcon />
+        )}{" "}
+        Continue with Google
       </Button>
 
       <div className="relative">
@@ -88,7 +93,9 @@ function SignUpForm() {
           <Separator className="w-full" />
         </div>
         <div className="relative flex justify-center text-xs uppercase">
-          <span className="bg-background px-2 text-muted-foreground">Or continue with</span>
+          <span className="bg-background px-2 text-muted-foreground">
+            Or continue with
+          </span>
         </div>
       </div>
 
@@ -135,7 +142,11 @@ function SignUpForm() {
           className="w-full h-11"
           size="lg"
         >
-          {isEmailLoading ? <Loader2 className="animate-spin" /> : "Create account"}
+          {isEmailLoading ? (
+            <Loader2 className="animate-spin" />
+          ) : (
+            "Create account"
+          )}
         </Button>
       </div>
     </div>
@@ -157,20 +168,29 @@ export default function SignUpPage() {
 
       <Card className="w-[400px] shadow-lg border-0">
         <CardHeader className="text-center pb-4">
-          <CardTitle className="text-2xl font-semibold">Create your account</CardTitle>
+          <CardTitle className="text-2xl font-semibold">
+            Create your account
+          </CardTitle>
           <CardDescription className="text-base">
             Get started with your free account today
           </CardDescription>
         </CardHeader>
         <CardContent className="pt-0">
-          <Suspense fallback={<div className="text-center">
-            <Loader2 className="animate-spin" />
-          </div>}>
+          <Suspense
+            fallback={
+              <div className="text-center">
+                <Loader2 className="animate-spin" />
+              </div>
+            }
+          >
             <SignUpForm />
           </Suspense>
           <div className="mt-6 text-center text-sm">
             Already have an account?{" "}
-            <Link href="/auth/login" className="font-medium text-primary underline-offset-4 hover:underline">
+            <Link
+              href="/login"
+              className="font-medium text-primary underline-offset-4 hover:underline"
+            >
               Sign in
             </Link>
           </div>

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -23,7 +23,7 @@ export function Header() {
           GitHub
         </Button>
       </Link>
-      <Link href={session ? "/editor" : "/auth/login"}>
+      <Link href={session ? "/editor" : "/login"}>
         <Button size="sm" className="text-sm ml-4">
           Start editing
           <ArrowRight className="h-4 w-4" />

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -7,7 +7,7 @@ export async function middleware(request: NextRequest) {
   const session = getSessionCookie(request);
 
   if (path === "/editor" && !session && process.env.NODE_ENV === "production") {
-    const loginUrl = new URL("/auth/login", request.url);
+    const loginUrl = new URL("/login", request.url);
     loginUrl.searchParams.set("redirect", request.url);
     return NextResponse.redirect(loginUrl);
   }


### PR DESCRIPTION
- Fix login/signup page links to use /login and /signup instead of /auth/login and /auth/signup
- Update header component to redirect to correct login path
- Fix middleware redirect to use correct login URL
- Improve code formatting for better readability in auth components

The (auth) folder structure in Next.js App Router creates routes without the 'auth' prefix, so all internal links should point to /login and /signup directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved formatting and readability of login and signup pages, including multi-line JSX for conditional rendering and separators.

- **Bug Fixes**
  - Updated navigation and redirect paths from "/auth/login" and "/auth/signup" to simplified "/login" and "/signup" routes across the app for a more consistent user experience.

- **Chores**
  - Adjusted navigation links and middleware redirects to use updated authentication routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->