### PR TITLE
fix: support context menu on track name and fix bugs of zooming in timeline track content

### DIFF
--- a/apps/web/src/components/editor/timeline.tsx
+++ b/apps/web/src/components/editor/timeline.tsx
@@ -482,7 +482,8 @@ export function Timeline() {
   // Prevent explorer zooming in/out when in timeline
   useEffect(() => {
     const preventZoom = (e: WheelEvent) => {
-      if (isInTimeline && (e.ctrlKey || e.metaKey)) {
+      // if (isInTimeline && (e.ctrlKey || e.metaKey)) {
+      if (isInTimeline && (e.ctrlKey || e.metaKey) && timelineRef.current?.contains(e.target as Node)) {
         e.preventDefault();
       }
     };
@@ -825,7 +826,6 @@ export function Timeline() {
                 }}
                 onClick={handleTimelineAreaClick}
                 onMouseDown={handleTimelineMouseDown}
-                onWheel={handleWheel}
               >
                 {tracks.length === 0 ? (
                   <div className="absolute inset-0 flex items-center justify-center">

--- a/apps/web/src/components/editor/timeline.tsx
+++ b/apps/web/src/components/editor/timeline.tsx
@@ -49,6 +49,7 @@ export function Timeline() {
   const [zoomLevel, setZoomLevel] = useState(1);
   const dragCounterRef = useRef(0);
   const timelineRef = useRef<HTMLDivElement>(null);
+  const [isInTimeline, setIsInTimeline] = useState(false);
 
   // Unified context menu state
   const [contextMenu, setContextMenu] = useState<{
@@ -477,10 +478,29 @@ export function Timeline() {
     toast.success("Deleted selected clip(s)");
   };
 
+
+  // Prevent explorer zooming in/out when in timeline
+  useEffect(() => {
+    const preventZoom = (e: WheelEvent) => {
+      if (isInTimeline && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+      }
+    };
+
+    document.addEventListener('wheel', preventZoom, { passive: false });
+    
+    return () => {
+      document.removeEventListener('wheel', preventZoom);
+    };
+  }, [isInTimeline]);
+
   return (
     <div
       className={`h-full flex flex-col transition-colors duration-200 relative ${isDragOver ? "bg-accent/30 border-accent" : ""}`}
       {...dragProps}
+      onMouseEnter={() => setIsInTimeline(true)}
+      onMouseLeave={() => setIsInTimeline(false)}
+      onWheel={handleWheel}
     >
       {/* Show overlay when dragging media over the timeline */}
       {isDragOver && (
@@ -758,25 +778,35 @@ export function Timeline() {
                   <div
                     key={track.id}
                     className="h-[60px] flex items-center px-3 border-b border-muted/30 bg-background group"
+                    onContextMenu={(e) => {
+                      e.preventDefault();
+                      setContextMenu({
+                        type: 'track',
+                        trackId: track.id,
+                        x: e.clientX,
+                        y: e.clientY,
+                      });
+                    }}
                   >
-                    <div className="flex items-center gap-2 flex-1 min-w-0">
+                    <div className="flex items-center flex-1 min-w-0">
                       <div
-                        className={`w-3 h-3 rounded-full flex-shrink-0 ${track.type === "video"
-                          ? "bg-blue-500"
-                          : track.type === "audio"
+                        className={`w-3 h-3 rounded-full flex-shrink-0 ${
+                          track.type === "video"
+                            ? "bg-blue-500"
+                            : track.type === "audio"
                             ? "bg-green-500"
                             : "bg-purple-500"
-                          }`}
+                        }`}
                       />
-                      <span className="text-sm font-medium truncate">
+                      <span className="ml-2 text-sm font-medium truncate">
                         {track.name}
                       </span>
-                      {track.muted && (
-                        <span className="ml-2 text-xs text-red-500 font-semibold">
-                          Muted
-                        </span>
-                      )}
                     </div>
+                    {track.muted && (
+                      <span className="ml-2 text-xs text-red-500 font-semibold flex-shrink-0">
+                        Muted
+                      </span>
+                    )}
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
## Description
Fix bugs:
1. support the context menu in track's name area 
2. fix the zooming bug in timeline tracks content area

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Node version:
* Browser (if applicable):
* Operating System:

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/d7a95b7c-470c-4873-bc62-a56230b7fa94)
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Disabled browser zoom (Ctrl/Cmd + wheel) while the mouse is over the timeline for smoother interaction.
  - Added a custom right-click context menu to track labels in the timeline.

- **Style**
  - Adjusted track label layout for improved appearance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->