### PR TITLE
fix(hero): improve spacing and prevent footer overlap with email section in landing page

### DIFF
--- a/apps/web/src/components/landing/hero.tsx
+++ b/apps/web/src/components/landing/hero.tsx
@@ -82,12 +82,12 @@ export function Hero({ signupCount }: HeroProps) {
   };
 
   return (
-    <div className="relative min-h-[calc(100vh-4rem)] flex flex-col items-center justify-center text-center px-4">
+    <div className="min-h-[calc(100vh-4rem)] flex flex-col justify-between items-center text-center px-4">
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 1 }}
-        className="max-w-3xl mx-auto"
+        className="max-w-3xl mx-auto w-full flex-1 flex flex-col justify-center"
       >
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -148,7 +148,7 @@ export function Hero({ signupCount }: HeroProps) {
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.8, duration: 0.6 }}
-            className="mt-6 inline-flex items-center gap-2 bg-muted/30 px-4 py-2 rounded-full text-sm text-muted-foreground"
+            className="mt-8 inline-flex items-center gap-2 bg-muted/30 px-4 py-2 rounded-full text-sm text-muted-foreground justify-center"
           >
             <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
             <span>{signupCount.toLocaleString()} people already joined</span>
@@ -157,7 +157,7 @@ export function Hero({ signupCount }: HeroProps) {
       </motion.div>
 
       <motion.div
-        className="absolute bottom-12 left-0 right-0 text-center text-sm text-muted-foreground/60"
+        className="mb-8 text-center text-sm text-muted-foreground/60"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 0.8, duration: 0.8 }}


### PR DESCRIPTION

**fix(hero): improve spacing and prevent footer overlap in hero section (#51)**

## Description

This PR restructures the landing page hero section to resolve a visual bug where the "Currently in beta • Open source on GitHub" footer could overlap with other content, especially on smaller screens.  
The "people already joined" badge is now correctly placed between the email form and the beta section, with improved spacing for better readability and responsiveness.

Fixes #51

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manually tested on Chrome (v124) and Windows 10 at various screen sizes (including 1280x720)
- Verified that the footer no longer overlaps and spacing is consistent
- Checked that the "people already joined" badge updates and displays correctly

**Test Configuration**:
* Node version: [your version]
* Browser: Chrome v124
* Operating System: Windows 10

## Screenshots 
Before :- 
![image](https://github.com/user-attachments/assets/8365827b-6c88-42cc-ac17-644a04064d21)
After:-
![image](https://github.com/user-attachments/assets/9fd970d9-0396-46f5-b658-e6017266b66c)



## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my code
- My changes generate no new warnings
- New and existing unit tests pass locally with my changes

## Additional context

Only the hero section was changed.  
This improves the visual consistency and professionalism of the landing page, especially on smaller screens.
