### PR TITLE
fix: drizzle schema path configuration in web app

### DIFF
--- a/apps/web/drizzle.config.ts
+++ b/apps/web/drizzle.config.ts
@@ -13,7 +13,7 @@ if (!process.env.DATABASE_URL) {
 }
 
 export default {
-  schema: "./src/lib/db/schema.ts",
+  schema: "../../packages/db/src/schema.ts",
   dialect: "postgresql",
   dbCredentials: {
     url: process.env.DATABASE_URL,


### PR DESCRIPTION
## Description

Fixed the drizzle schema path configuration in the web app that was causing the db:push:local command to fail. The configuration was pointing to a non-existent schema file, but the actual schema is located in the packages/db package within the monorepo structure.

Fixes #78 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Tests

## How Has This Been Tested?

- [x] Test A: Ran bun run db:push:local command successfully

**Test Configuration**:
* Node version:
* Browser (if applicable):
* Operating System:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

In `apps/web/drizzle.config.ts`, updated schema path from "./src/lib/db/schema.ts" to "../../packages/db/src/schema.ts"