### PR TITLE
docs: change commands in README adapted to different platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,16 @@ Before you begin, ensure you have the following installed on your system:
     Navigate into the web app's directory and create a `.env` file from the example:
     ```bash
     cd apps/web
-    cp .env.example .env
+
+    
+    # Unix/Linux/Mac
+    cp .env.example .env.local
+
+    # Windows Command Prompt
+    copy .env.example .env.local
+    
+    # Windows PowerShell
+    Copy-Item .env.example .env.local
     ```
     *The default values in the `.env` file should work for local development.*
 


### PR DESCRIPTION
## Description

In README.md, the command to copy environment variables is only available for Unix-Like platforms.

Fixes #57

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:
* Node version:
* Browser (if applicable):
* Operating System:

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

Add any other context about the pull request here. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated setup instructions to include platform-specific commands for copying environment variable files, ensuring compatibility across Unix/Linux/Mac, Windows Command Prompt, and Windows PowerShell.
  - Clarified that the target environment file should be named `.env.local`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->