### PR TITLE
Fix: Reset playhead to start after video ends

### DIFF
--- a/apps/web/src/stores/playback-store.ts
+++ b/apps/web/src/stores/playback-store.ts
@@ -21,7 +21,13 @@ const startTimer = (store: any) => {
 
       const newTime = state.currentTime + delta * state.speed;
       if (newTime >= state.duration) {
+        // When video completes, pause and reset playhead to start
         state.pause();
+        state.setCurrentTime(0);
+        // Notify video elements to sync with reset
+        window.dispatchEvent(
+          new CustomEvent("playback-seek", { detail: { time: 0 } })
+        );
       } else {
         state.setCurrentTime(newTime);
         // Notify video elements to sync


### PR DESCRIPTION

## Description

This PR fixes an issue where the playhead remains at the end of the timeline after a video finishes playing. Now, when a video reaches its end, the playhead automatically resets to 0s, improving the user experience and aligning with common video editor behavior.

Fixes #99 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually tested by playing a video in the editor and confirming that the playhead resets to the beginning once the video playback completes.

**Test Configuration**:
* Node version: v18.x
* Browser (if applicable): Chrome
* Operating System: macOS

## Screenshots (if applicable)
<img width="1058" alt="image" src="https://github.com/user-attachments/assets/6797a01f-0ef1-4a5e-a843-5798d2b9f34c" />
whenever the playhead reaches end of video it automatically comes to front. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

No Addtional Context