### PR TITLE
Feature: Add progress indicator for large file imports

### DIFF
--- a/apps/web/src/components/editor/media-panel.tsx
+++ b/apps/web/src/components/editor/media-panel.tsx
@@ -17,27 +17,28 @@ export function MediaPanel() {
   const { mediaItems, addMediaItem, removeMediaItem } = useMediaStore();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isProcessing, setIsProcessing] = useState(false);
+  const [progress, setProgress] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
   const [mediaFilter, setMediaFilter] = useState("all");
 
   const processFiles = async (files: FileList | File[]) => {
-    // If no files, do nothing
-    if (!files?.length) return;
-
+    if (!files || files.length === 0) return;
     setIsProcessing(true);
+    setProgress(0);
     try {
       // Process files (extract metadata, generate thumbnails, etc.)
-      const items = await processMediaFiles(files);
+      const processedItems = await processMediaFiles(files, (p) =>
+        setProgress(p)
+      );
       // Add each processed media item to the store
-      items.forEach((item) => {
-        addMediaItem(item);
-      });
+      processedItems.forEach((item) => addMediaItem(item));
     } catch (error) {
-      // Show error if processing fails
-      console.error("File processing failed:", error);
+      // Show error toast if processing fails
+      console.error("Error processing files:", error);
       toast.error("Failed to process files");
     } finally {
       setIsProcessing(false);
+      setProgress(0);
     }
   };
 
@@ -241,15 +242,12 @@ export function MediaPanel() {
               {isProcessing ? (
                 <>
                   <Upload className="h-4 w-4 animate-spin" />
-                  <span className="hidden md:inline ml-2">Processing...</span>
+                  <span className="hidden md:inline ml-2">{progress}%</span>
                 </>
               ) : (
                 <>
                   <Plus className="h-4 w-4" />
-                  <span
-                    className="hidden sm:inline ml-2"
-                    aria-label="Add file"
-                  >
+                  <span className="hidden sm:inline ml-2" aria-label="Add file">
                     Add
                   </span>
                 </>

--- a/apps/web/src/lib/media-processing.ts
+++ b/apps/web/src/lib/media-processing.ts
@@ -62,6 +62,9 @@ export async function processMediaFiles(
         aspectRatio,
       });
 
+      // Yield back to the event loop to keep the UI responsive
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
       completed += 1;
       if (onProgress) {
         const percent = Math.round((completed / total) * 100);

--- a/apps/web/src/lib/media-processing.ts
+++ b/apps/web/src/lib/media-processing.ts
@@ -11,10 +11,14 @@ import {
 export interface ProcessedMediaItem extends Omit<MediaItem, "id"> {}
 
 export async function processMediaFiles(
-  files: FileList | File[]
+  files: FileList | File[],
+  onProgress?: (progress: number) => void
 ): Promise<ProcessedMediaItem[]> {
   const fileArray = Array.from(files);
   const processedItems: ProcessedMediaItem[] = [];
+
+  const total = fileArray.length;
+  let completed = 0;
 
   for (const file of fileArray) {
     const fileType = getFileType(file);
@@ -57,6 +61,12 @@ export async function processMediaFiles(
         duration,
         aspectRatio,
       });
+
+      completed += 1;
+      if (onProgress) {
+        const percent = Math.round((completed / total) * 100);
+        onProgress(percent);
+      }
     } catch (error) {
       console.error("Error processing file:", file.name, error);
       toast.error(`Failed to process ${file.name}`);


### PR DESCRIPTION
## Description

This PR adds a progress indicator (spinner and percentage) during long-running operations like importing large files or multiple files. It improves user experience by giving clear visual feedback that the app is processing, preventing confusion or repeated actions.

Fixes #456 (replace with actual issue number if applicable)
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested manually by importing multiple large files in the editor. The progress spinner appears and updates correctly, and disappears once the operation completes.

**Test Configuration**:
* Node version: 18.x
* Browser (if applicable): Chrome
* Operating System: macOS

## Screenshots (if applicable)

<img width="243" alt="image" src="https://github.com/user-attachments/assets/de648277-3e9c-4117-83ae-4e02f836e5c0" />

<img width="507" alt="image" src="https://github.com/user-attachments/assets/1ff2c062-0c04-4983-888a-844f59f11cc2" />



Add screenshots to help explain your changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Additional context

This change helps users feel more confident that the app is working, especially when handling large or multiple files where there's usually a delay.

