### PR TITLE
Changed Preview Empty placeholder to No media added to timeline  https://github.com/OpenCut-app/OpenCut/issues/110

### DIFF
--- a/apps/web/src/components/editor/preview-panel.tsx
+++ b/apps/web/src/components/editor/preview-panel.tsx
@@ -249,7 +249,7 @@ export function PreviewPanel() {
           {activeClips.length === 0 ? (
             <div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
               {tracks.length === 0
-                ? "Drop media to start editing"
+                ? "No media added to timeline"
                 : "No clips at current time"}
             </div>
           ) : (


### PR DESCRIPTION
## Description

This pr addresses the issue: https://github.com/OpenCut-app/OpenCut/issues/110. I have changed "Drop media to start editing" to "No media added to timeline" when no tracks are present, to indicate that no content is available to preview.

Fixes # https://github.com/OpenCut-app/OpenCut/issues/110

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Node version: 22
* Browser (if applicable): Brave
* Operating System: MocOs

## Screenshots (if applicable)
<img width="1696" alt="image" src="https://github.com/user-attachments/assets/1faba11c-8bb3-4242-ad2a-43c39c559bc9" />

Add screenshots to help explain your changes.

## Checklist:

- [ ] I have performed a self-review of my code
