### PR TITLE
chore(dev): add docker-compose.dev.yaml and dev scripts for local development, updated CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,75 +22,98 @@ Thank you for your interest in contributing to OpenCut! This document provides g
 
 1. Start the database and Redis services:
 
-   ```bash
-   # From project root
-   docker-compose up -d
-   ```
+    ```bash
+    # From project root
+    bun run docker:dev
+
+    # Or with npm
+    npm run docker:dev
+    ```
+
+    > This uses `docker-compose.dev.yaml` to start only the required services for development.
 
 2. Navigate to the web app directory:
 
-   ```bash
-   cd apps/web
-   ```
+    ```bash
+    cd apps/web
+    ```
 
 3. Copy `.env.example` to `.env.local`:
 
-   ```bash
-   # Unix/Linux/Mac
-   cp .env.example .env.local
+    ```bash
+    # Unix/Linux/Mac
+    cp .env.example .env.local
 
-   # Windows Command Prompt
-   copy .env.example .env.local
+    # Windows Command Prompt
+    copy .env.example .env.local
 
-   # Windows PowerShell
-   Copy-Item .env.example .env.local
-   ```
+    # Windows PowerShell
+    Copy-Item .env.example .env.local
+    ```
 
 4. Configure required environment variables in `.env.local`:
 
-   **Required Variables:**
+    **Required Variables:**
 
-   ```bash
-   # Database (matches docker-compose.yaml)
-   DATABASE_URL="postgresql://opencut:opencutthegoat@localhost:5432/opencut"
+    ```env
+    # Database (matches docker-compose.dev.yaml)
+    DATABASE_URL="postgresql://opencut:opencutthegoat@localhost:5432/opencut"
 
-   # Generate a secure secret for Better Auth
-   BETTER_AUTH_SECRET="your-generated-secret-here"
-   BETTER_AUTH_URL="http://localhost:3000"
+    # Generate a secure secret for Better Auth
+    BETTER_AUTH_SECRET="your-generated-secret-here"
+    BETTER_AUTH_URL="http://localhost:3000"
 
-   # Redis (matches docker-compose.yaml)
-   UPSTASH_REDIS_REST_URL="http://localhost:8079"
-   UPSTASH_REDIS_REST_TOKEN="example_token"
+    # Redis (matches docker-compose.dev.yaml)
+    UPSTASH_REDIS_REST_URL="http://localhost:8079"
+    UPSTASH_REDIS_REST_TOKEN="example_token"
 
-   # Development
-   NODE_ENV="development"
-   ```
+    # Development
+    NODE_ENV="development"
+    ```
 
-   **Generate BETTER_AUTH_SECRET:**
+    **Generate BETTER_AUTH_SECRET:**
 
-   ```bash
-   # Unix/Linux/Mac
-   openssl rand -base64 32
+    ```bash
+    # Unix/Linux/Mac
+    openssl rand -base64 32
 
-   # Windows PowerShell (simple method)
-   [System.Web.Security.Membership]::GeneratePassword(32, 0)
+    # Windows PowerShell (simple method)
+    [System.Web.Security.Membership]::GeneratePassword(32, 0)
 
-   # Cross-platform (using Node.js)
-   node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+    # Cross-platform (using Node.js)
+    node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
 
-   # Or use an online generator: https://generate-secret.vercel.app/32
-   ```
+    # Or use an online generator: https://generate-secret.vercel.app/32
+    ```
 
-   **Optional Variables (for Google OAuth):**
+    **Optional Variables (for Google OAuth):**
 
-   ```bash
-   # Only needed if you want to test Google login
-   GOOGLE_CLIENT_ID="your-google-client-id"
-   GOOGLE_CLIENT_SECRET="your-google-client-secret"
-   ```
+    ```env
+    # Only needed if you want to test Google login
+    GOOGLE_CLIENT_ID="your-google-client-id"
+    GOOGLE_CLIENT_SECRET="your-google-client-secret"
+    ```
 
-5. Run database migrations: `bun run db:migrate`
-6. Start the development server: `bun run dev`
+5. Run database migrations:
+
+    ```bash
+    bun run db:migrate
+    ```
+
+6. Start the development server:
+
+    ```bash
+    bun run dev
+    ```
+
+### Stopping & Resetting Dev Containers
+
+You can also stop or reset your dev environment using the following scripts:
+
+```bash
+bun run docker:dev:stop   # Stop containers without removing them
+bun run docker:dev:down   # Stop and remove containers/networks
+bun run docker:dev:reset  # Fully reset containers AND volumes (wipes DB!)
 
 ## How to Contribute
 
@@ -138,3 +161,4 @@ Thank you for your interest in contributing to OpenCut! This document provides g
 - Help others in discussions and issues
 
 Thank you for contributing!
+```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -115,6 +115,8 @@ bun run docker:dev:stop   # Stop containers without removing them
 bun run docker:dev:down   # Stop and remove containers/networks
 bun run docker:dev:reset  # Fully reset containers AND volumes (wipes DB!)
 
+```
+
 ## How to Contribute
 
 ### Reporting Bugs
@@ -161,4 +163,3 @@ bun run docker:dev:reset  # Fully reset containers AND volumes (wipes DB!)
 - Help others in discussions and issues
 
 Thank you for contributing!
-```

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,56 @@
+services:
+    db:
+        image: postgres:17
+        restart: unless-stopped
+        environment:
+            POSTGRES_USER: opencut
+            POSTGRES_PASSWORD: opencutthegoat
+            POSTGRES_DB: opencut
+        volumes:
+            - postgres_data:/var/lib/postgresql/data
+        ports:
+            - "5432:5432"
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U opencut"]
+            interval: 30s
+            timeout: 10s
+            retries: 5
+            start_period: 10s
+
+    redis:
+        image: redis:7-alpine
+        restart: unless-stopped
+        ports:
+            - "6379:6379"
+        healthcheck:
+            test: ["CMD", "redis-cli", "ping"]
+            interval: 30s
+            timeout: 10s
+            retries: 5
+            start_period: 10s
+
+    serverless-redis-http:
+        image: hiett/serverless-redis-http:latest
+        ports:
+            - "8079:80"
+        environment:
+            SRH_MODE: env
+            SRH_TOKEN: example_token
+            SRH_CONNECTION_STRING: "redis://redis:6379"
+        depends_on:
+            redis:
+                condition: service_healthy
+        healthcheck:
+            test:
+                ["CMD-SHELL", "wget --spider -q http://127.0.0.1:80 || exit 1"]
+            interval: 30s
+            timeout: 10s
+            retries: 5
+            start_period: 10s
+
+volumes:
+    postgres_data:
+
+networks:
+    default:
+        name: opencut-network

--- a/package.json
+++ b/package.json
@@ -1,22 +1,26 @@
 {
-  "name": "opencut",
-  "packageManager": "bun@1.2.17",
-  "devDependencies": {
-    "turbo": "^2.5.4"
-  },
-  "workspaces": [
-    "apps/*",
-    "packages/*"
-  ],
-  "scripts": {
-    "dev": "turbo run dev",
-    "build": "turbo run build",
-    "check-types": "turbo run check-types",
-    "lint": "turbo run lint",
-    "format": "turbo run format"
-  },
-  "dependencies": {
-    "next": "^15.3.4",
-    "wavesurfer.js": "^7.9.8"
-  }
+	"name": "opencut",
+	"packageManager": "bun@1.2.17",
+	"devDependencies": {
+		"turbo": "^2.5.4"
+	},
+	"workspaces": [
+		"apps/*",
+		"packages/*"
+	],
+	"scripts": {
+		"dev": "turbo run dev",
+		"build": "turbo run build",
+		"check-types": "turbo run check-types",
+		"lint": "turbo run lint",
+		"format": "turbo run format",
+		"docker:dev": "docker compose -f docker-compose.dev.yaml up -d",
+		"docker:dev:stop": "docker compose -f docker-compose.dev.yaml stop",
+		"docker:dev:down": "docker compose -f docker-compose.dev.yaml down",
+		"docker:dev:reset": "docker compose -f docker-compose.dev.yaml down -v"
+	},
+	"dependencies": {
+		"next": "^15.3.4",
+		"wavesurfer.js": "^7.9.8"
+	}
 }


### PR DESCRIPTION
## Description

This PR improves the local development setup by introducing a dedicated `docker-compose.dev.yaml` file and associated `package.json` scripts. These changes prevent port conflicts that occur when using the existing `docker-compose.yaml`, which builds and serves the app on port 3000 — the same port used by the development server (`bun run dev`).

It also updates `CONTRIBUTING.md` with clear instructions for contributors, making it easier to get started with a proper dev environment.

### Changes included:
- Added `docker-compose.dev.yaml` with only Postgres and Redis services
- Added the following dev scripts to `package.json`:
  - `docker:dev`
  - `docker:dev:stop`
  - `docker:dev:down`
  - `docker:dev:reset`
- Updated `CONTRIBUTING.md` to reflect the new development setup

Fixes #  
N/A (improves contributor experience)

## Type of change

- [x] This change requires a documentation update  
- [x] Code refactoring  

## How Has This Been Tested?

- Verified all new scripts (`docker:dev`, `stop`, `down`, `reset`) work as expected on macOS
- Confirmed `bun run dev` launches without port 3000 conflicts
- Ran migrations and accessed app on `localhost:3000`
- Confirmed Redis and Postgres containers start and stop cleanly

**Test Configuration:**
- Node version: v24.1.0  
- Browser: Chrome and Arc  
- Operating System: macOS 15.4

## Screenshots (if applicable)

**N/A**

## Checklist:

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [x] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [ ] New and existing unit tests pass locally with my changes  
- [ ] Any dependent changes have been merged and published in downstream modules  

## Additional context

Prior to this change, running `docker-compose up` and then `bun run dev` would result in a port conflict because both processes used port 3000. This update ensures a clean, isolated development environment using `docker-compose.dev.yaml` alongside `bun run dev`, improving the DX for all contributors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved and expanded development setup instructions in the contributing guide, including detailed environment variable configuration, database and Redis setup, and Docker workflow commands.
  * Added instructions for generating secure authentication secrets and optional Google OAuth setup.
  * Enhanced formatting and clarity throughout the guide.

* **Chores**
  * Introduced a new Docker Compose configuration for development with PostgreSQL, Redis, and serverless Redis HTTP services.
  * Added npm scripts for managing development Docker containers (start, stop, down, reset).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->