### PR TITLE
fix:Update state access in TimelineClip component

### DIFF
--- a/apps/web/src/components/editor/timeline-clip.tsx
+++ b/apps/web/src/components/editor/timeline-clip.tsx
@@ -1,44 +1,42 @@
 "use client";
 
-import { useState } from "react";
-import { Button } from "../ui/button";
-import {
-  MoreVertical,
-  Scissors,
-  Trash2,
-  SplitSquareHorizontal,
-  Music,
-  ChevronRight,
-  ChevronLeft,
-} from "lucide-react";
 import { useMediaStore } from "@/stores/media-store";
-import { useTimelineStore } from "@/stores/timeline-store";
 import { usePlaybackStore } from "@/stores/playback-store";
-import AudioWaveform from "./audio-waveform";
+import { useTimelineStore } from "@/stores/timeline-store";
+import { ResizeState, TimelineClipProps } from "@/types/timeline";
+import {
+  ChevronLeft,
+  ChevronRight,
+  MoreVertical,
+  Music,
+  Scissors,
+  SplitSquareHorizontal,
+  Trash2,
+} from "lucide-react";
+import { useState } from "react";
 import { toast } from "sonner";
-import { TimelineClipProps, ResizeState } from "@/types/timeline";
+import { Button } from "../ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
-  DropdownMenuTrigger,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
-import { isDragging } from "motion/react";
+import AudioWaveform from "./audio-waveform";
 
 export function TimelineClip({
   clip,
   track,
   zoomLevel,
   isSelected,
-  onContextMenu,
   onClipMouseDown,
   onClipClick,
 }: TimelineClipProps) {
-  const { mediaItems } = useMediaStore();
+  const mediaItems = useMediaStore((s) => s.mediaItems);
   const {
     updateClipTrim,
     addClipToTrack,
@@ -49,7 +47,7 @@ export function TimelineClip({
     splitAndKeepRight,
     separateAudio,
   } = useTimelineStore();
-  const { currentTime } = usePlaybackStore();
+  const currentTime = usePlaybackStore((s) => s.currentTime);
 
   const [resizing, setResizing] = useState<ResizeState | null>(null);
   const [clipMenuOpen, setClipMenuOpen] = useState(false);
@@ -299,7 +297,7 @@ export function TimelineClip({
         )} ${isSelected ? "ring-2 ring-primary ring-offset-1" : ""}`}
         onClick={(e) => onClipClick && onClipClick(e, clip)}
         onMouseDown={handleClipMouseDown}
-        onContextMenu={(e) => onContextMenu && onContextMenu(e, clip.id)}
+        // onContextMenu={(e) => onContextMenu && onContextMenu(e, clip.id)}
       >
         <div className="absolute inset-1 flex items-center p-1">
           {renderClipContent()}


### PR DESCRIPTION
## Description

I was trying to build OpenCut locally, but faced this issue while building. So I have commented out `onContextMenu` which was removed in the last couple of commits.

Fixes #155 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran the project locally after making the change, according to what is told in CONTRIBUTING.md. Please let me know in case this is not required.

**Test Configuration**:
* Node version: v22.14.0
* Browser (if applicable): Brave Browser
* Operating System: MacOS

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved organization of import statements for better clarity.
  * Updated state selector usage for more efficient store subscriptions.

* **Bug Fixes**
  * Disabled the context menu event on timeline clips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->