### PR TITLE
feat: make Open Source badge a clickable link to GitHub repository

### DIFF
--- a/apps/web/src/app/contributors/page.tsx
+++ b/apps/web/src/app/contributors/page.tsx
@@ -78,10 +78,15 @@ export default async function ContributorsPage() {
         <div className="relative container mx-auto px-4 py-16">
           <div className="max-w-6xl mx-auto">
             <div className="text-center mb-20">
-              <Badge variant="secondary" className="gap-2 mb-6">
-                <GithubIcon className="h-3 w-3" />
-                Open Source
-              </Badge>
+              <Link
+                href={"https://github.com/OpenCut-app/OpenCut"}
+                target="_blank"
+              >
+                <Badge variant="secondary" className="gap-2 mb-6">
+                  <GithubIcon className="h-3 w-3" />
+                  Open Source
+                </Badge>
+              </Link>
               <h1 className="text-5xl md:text-6xl font-bold tracking-tight mb-6">
                 Contributors
               </h1>


### PR DESCRIPTION
made Open Source badge a clickable link to GitHub repository


https://github.com/user-attachments/assets/3922e58a-0d2a-4811-aa18-25765d72ef78

