### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Before you begin, ensure you have the following installed on your system:
 1.  **Clone the repository**
 
     ```bash
-    git clone <repo-url>
+    git clone https://github.com/OpenCut-app/OpenCut.git
     cd OpenCut
     ```
 


### PR DESCRIPTION
## Description

Replaced the placeholder repository URL (`<repo-url>`) in the `README.md` with the actual HTTPS clone URL for the OpenCut GitHub repository. This improves onboarding by making the clone step immediately usable without requiring manual substitution.

Fixes: No associated issue

## Type of change

* [x] Documentation update

## How Has This Been Tested?

No code changes were made. Visual confirmation that the correct repo URL is now in place and renders properly in the markdown preview.

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my change
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings

## Additional context

This makes the project more beginner-friendly and avoids confusion during setup. It’s a minor but necessary polish to the UX and documentation.