### PR TITLE
add(minor): GH stars count and Date method 

### DIFF
--- a/apps/web/src/components/editor/media-panel/views/text.tsx
+++ b/apps/web/src/components/editor/media-panel/views/text.tsx
@@ -1,13 +1,23 @@
 import { DraggableMediaItem } from "@/components/ui/draggable-item";
+import { useState } from "react";
 
 export function TextView() {
+  const [text, setText] = useState("Default text");
+
+  const handleUpdateText = () => {
+    const newText = prompt("Enter your text:", "New text") || "New text";
+    setText(newText);
+
+    // TODO: Add this to your actual video/canvas layer system instead!
+    console.log("Add to video:", newText);
+  };
   return (
     <div className="p-4">
       <DraggableMediaItem
-        name="Default text"
+        name={text}
         preview={
           <div className="flex items-center justify-center w-full h-full bg-accent rounded">
-            <span className="text-xs select-none">Default text</span>
+            <span className="text-xs select-none">{text}</span>
           </div>
         }
         dragData={{
@@ -18,6 +28,7 @@ export function TextView() {
         }}
         aspectRatio={1}
         showLabel={false}
+        onPlusClick={handleUpdateText}
       />
     </div>
   );

--- a/apps/web/src/components/editor/media-panel/views/text.tsx
+++ b/apps/web/src/components/editor/media-panel/views/text.tsx
@@ -1,23 +1,23 @@
 import { DraggableMediaItem } from "@/components/ui/draggable-item";
-import { useState } from "react";
+// import { useState } from "react";
 
 export function TextView() {
-  const [text, setText] = useState("Default text");
+  // const [text, setText] = useState("Default text");
 
-  const handleUpdateText = () => {
-    const newText = prompt("Enter your text:", "New text") || "New text";
-    setText(newText);
+  // const handleUpdateText = () => {
+  //   const newText = prompt("Enter your text:", "New text") || "New text";
+  //   setText(newText);
 
-    // TODO: Add this to your actual video/canvas layer system instead!
-    console.log("Add to video:", newText);
-  };
+  //   // TODO: Add this to your actual video/canvas layer system instead!
+  //   console.log("Add to video:", newText);
+  // };
   return (
     <div className="p-4">
       <DraggableMediaItem
-        name={text}
+        name="Default text"
         preview={
           <div className="flex items-center justify-center w-full h-full bg-accent rounded">
-            <span className="text-xs select-none">{text}</span>
+            <span className="text-xs select-none">Default text</span>
           </div>
         }
         dragData={{
@@ -28,7 +28,7 @@ export function TextView() {
         }}
         aspectRatio={1}
         showLabel={false}
-        onPlusClick={handleUpdateText}
+        // onPlusClick={handleUpdateText}
       />
     </div>
   );

--- a/apps/web/src/components/editor/media-panel/views/text.tsx
+++ b/apps/web/src/components/editor/media-panel/views/text.tsx
@@ -1,34 +1,35 @@
 import { DraggableMediaItem } from "@/components/ui/draggable-item";
-// import { useState } from "react";
+import { useState } from "react";
 
 export function TextView() {
-  // const [text, setText] = useState("Default text");
+  const [text, setText] = useState<string>("Default text");
 
-  // const handleUpdateText = () => {
-  //   const newText = prompt("Enter your text:", "New text") || "New text";
-  //   setText(newText);
+  const handleUpdateText = () => {
+    const newText: string =
+      prompt("Enter your text:", "New text") || "New text";
+    setText(newText);
 
-  //   // TODO: Add this to your actual video/canvas layer system instead!
-  //   console.log("Add to video:", newText);
-  // };
+    // TODO: Add this to your actual video/canvas layer system instead!
+    console.log("Add to video:", newText);
+  };
   return (
     <div className="p-4">
       <DraggableMediaItem
-        name="Default text"
+        name={text}
         preview={
           <div className="flex items-center justify-center w-full h-full bg-accent rounded">
-            <span className="text-xs select-none">Default text</span>
+            <span className="text-xs select-none">{text}</span>
           </div>
         }
         dragData={{
           id: "default-text",
           type: "text",
-          name: "Default text",
-          content: "Default text",
+          name: text,
+          content: text,
         }}
         aspectRatio={1}
         showLabel={false}
-        // onPlusClick={handleUpdateText}
+        onPlusClick={handleUpdateText}
       />
     </div>
   );

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -45,15 +45,18 @@ export function Footer() {
             <div className="flex gap-3">
               <Link
                 href="https://github.com/OpenCut-app/OpenCut"
-                className="text-muted-foreground hover:text-foreground transition-colors"
+                className="text-muted-foreground hover:text-foreground transition-colors flex items-center justify-center"
                 target="_blank"
                 rel="noopener noreferrer"
               >
                 <RiGithubLine className="h-5 w-5" />
+                <span className="text-foreground text-lg font-mono flex items-center">
+                  {star ? ` ${star}+` : "1k+"}
+                </span>
               </Link>
               <Link
                 href="https://x.com/OpenCutApp"
-                className="text-muted-foreground hover:text-foreground transition-colors"
+                className="text-muted-foreground hover:text-foreground transition-colors  flex items-center justify-center"
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -115,7 +118,9 @@ export function Footer() {
         {/* Bottom Section */}
         <div className="pt-2 flex flex-col md:flex-row justify-between items-center gap-4">
           <div className="flex items-center gap-4 text-sm text-muted-foreground">
-            <span>© 2025 OpenCut, All Rights Reserved</span>
+            <span>
+              © {new Date().getFullYear()} OpenCut, All Rights Reserved
+            </span>
           </div>
         </div>
       </div>

--- a/apps/web/src/components/ui/draggable-item.tsx
+++ b/apps/web/src/components/ui/draggable-item.tsx
@@ -16,6 +16,7 @@ export interface DraggableMediaItemProps {
   className?: string;
   showPlusOnDrag?: boolean;
   showLabel?: boolean;
+  onPlusClick?: () => void;
   rounded?: boolean;
 }
 
@@ -29,6 +30,7 @@ export function DraggableMediaItem({
   showPlusOnDrag = true,
   showLabel = true,
   rounded = true,
+  onPlusClick,
 }: DraggableMediaItemProps) {
   const [isDragging, setIsDragging] = useState(false);
   const [dragPosition, setDragPosition] = useState({ x: 0, y: 0 });
@@ -92,7 +94,10 @@ export function DraggableMediaItem({
           >
             {preview}
             {!isDragging && (
-              <PlusButton className="opacity-0 group-hover:opacity-100" />
+              <PlusButton
+                className="opacity-0 group-hover:opacity-100"
+                clickHandler={onPlusClick}
+              />
             )}
           </AspectRatio>
           {showLabel && (
@@ -138,11 +143,18 @@ export function DraggableMediaItem({
   );
 }
 
-function PlusButton({ className }: { className?: string }) {
+function PlusButton({
+  className,
+  clickHandler,
+}: {
+  className?: string;
+  clickHandler?: () => void;
+}) {
   return (
     <Button
       size="icon"
       className={cn("absolute bottom-2 right-2 size-4", className)}
+      onClick={clickHandler}
     >
       <Plus className="!size-3" />
     </Button>

--- a/apps/web/src/components/ui/draggable-item.tsx
+++ b/apps/web/src/components/ui/draggable-item.tsx
@@ -16,7 +16,7 @@ export interface DraggableMediaItemProps {
   className?: string;
   showPlusOnDrag?: boolean;
   showLabel?: boolean;
-  // onPlusClick?: () => void;
+  onPlusClick?: () => void;
   rounded?: boolean;
 }
 
@@ -30,7 +30,7 @@ export function DraggableMediaItem({
   showPlusOnDrag = true,
   showLabel = true,
   rounded = true,
-  // onPlusClick,
+  onPlusClick,
 }: DraggableMediaItemProps) {
   const [isDragging, setIsDragging] = useState(false);
   const [dragPosition, setDragPosition] = useState({ x: 0, y: 0 });
@@ -96,7 +96,7 @@ export function DraggableMediaItem({
             {!isDragging && (
               <PlusButton
                 className="opacity-0 group-hover:opacity-100"
-                // clickHandler={onPlusClick}
+                clickHandler={onPlusClick}
               />
             )}
           </AspectRatio>
@@ -154,7 +154,7 @@ function PlusButton({
     <Button
       size="icon"
       className={cn("absolute bottom-2 right-2 size-4", className)}
-      // onClick={clickHandler}
+      onClick={clickHandler}
     >
       <Plus className="!size-3" />
     </Button>

--- a/apps/web/src/components/ui/draggable-item.tsx
+++ b/apps/web/src/components/ui/draggable-item.tsx
@@ -16,7 +16,7 @@ export interface DraggableMediaItemProps {
   className?: string;
   showPlusOnDrag?: boolean;
   showLabel?: boolean;
-  onPlusClick?: () => void;
+  // onPlusClick?: () => void;
   rounded?: boolean;
 }
 
@@ -30,7 +30,7 @@ export function DraggableMediaItem({
   showPlusOnDrag = true,
   showLabel = true,
   rounded = true,
-  onPlusClick,
+  // onPlusClick,
 }: DraggableMediaItemProps) {
   const [isDragging, setIsDragging] = useState(false);
   const [dragPosition, setDragPosition] = useState({ x: 0, y: 0 });
@@ -96,7 +96,7 @@ export function DraggableMediaItem({
             {!isDragging && (
               <PlusButton
                 className="opacity-0 group-hover:opacity-100"
-                clickHandler={onPlusClick}
+                // clickHandler={onPlusClick}
               />
             )}
           </AspectRatio>
@@ -154,7 +154,7 @@ function PlusButton({
     <Button
       size="icon"
       className={cn("absolute bottom-2 right-2 size-4", className)}
-      onClick={clickHandler}
+      // onClick={clickHandler}
     >
       <Plus className="!size-3" />
     </Button>


### PR DESCRIPTION
## Description

Added missing GitHub stars count to the Footer component and used the Date() method in the copyright to make it future-proof.

Fixes # (issue)
n/a

## Type of change
Added the missing GitHub stars count to the footer component and utilized the Date() method in the copyright to ensure it remains future-proof.
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Tests

## Screenshots (if applicable)

### Before
![Screenshot 2025-07-07 031320](https://github.com/user-attachments/assets/38b5aa25-b11c-4f43-9698-26d69205dbdc)

### After
![Screenshot 2025-07-07 031329](https://github.com/user-attachments/assets/d7fe30da-eeff-4713-9db1-7d56655f0833)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added dynamic text editing in the media panel allowing users to update draggable text items interactively.
* **Style**
  * GitHub and Twitter links in the footer are now centered horizontally and vertically.
* **Chores**
  * The footer now automatically updates the copyright year to the current year.
  * GitHub link in the footer displays a star count next to its icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->