### PR TITLE
Create docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,66 @@
+name: Build and Publish Docker Images
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/opencut
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./apps/web/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
docker publish  action include github docker image and docker hub image.
● Description

  This GitHub Actions workflow automates the building and publishing of Docker images for the OpenCut application. It builds multi-platform Docker images (linux/amd64 and linux/arm64) from the web application Dockerfile and
  publishes them to both GitHub Container Registry (ghcr.io) and Docker Hub.

  The workflow triggers on pushes to the main branch, version tags (v*), and pull requests to main. It uses GitHub Actions cache for improved build performance and automatically generates appropriate tags based on branch names, PR
   numbers, and semantic versioning.

  Type of change

  - New feature (non-breaking change which adds functionality)

  How Has This Been Tested?

  This workflow will be automatically tested when:
  - Pushing to main branch
  - Creating version tags
  - Opening pull requests to main

  Test Configuration:
  - Platform: GitHub Actions (ubuntu-latest)
  - Docker Buildx: Multi-platform builds
  - Registries: GitHub Container Registry + Docker Hub

  Checklist:

  - My code follows the style guidelines of this project
  - I have performed a self-review of my code
  - My changes generate no new warnings
  - The workflow uses secure authentication methods
  - Multi-platform support is enabled
  - Caching is configured for improved performance

  Additional context

  The workflow publishes to both GitHub Container Registry (using repository name) and Docker Hub (using the opencut image name). It requires DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets to be configured in the repository
  settings for Docker Hub publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to build and publish Docker images to GitHub Container Registry and Docker Hub on code changes and releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->