### PR TITLE
docs: add note about npm workspace error and bun recommendation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,10 @@ Thank you for your interest in contributing to OpenCut! This document provides g
 4. Install dependencies: `bun install`
 5. Start the development server: `bun run dev`
 
-**Note:** If you see an error like `Unsupported URL Type "workspace:*"` when using `npm install`, use **bun** or **pnpm** instead.
+> **Note:** If you see an error like `Unsupported URL Type "workspace:*"` when running `npm install`, you have two options:
+>
+> 1. Upgrade to a recent npm version (v9 or later), which has full workspace protocol support.
+> 2. Use an alternative package manager such as **bun** or **pnpm**.
 
 ## Development Setup
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,6 +10,8 @@ Thank you for your interest in contributing to OpenCut! This document provides g
 4. Install dependencies: `bun install`
 5. Start the development server: `bun run dev`
 
+**Note:** If you see an error like `Unsupported URL Type "workspace:*"` when using `npm install`, use **bun** or **pnpm** instead.
+
 ## Development Setup
 
 ### Prerequisites


### PR DESCRIPTION
## Description

Added a note to `.github/CONTRIBUTING.md` that helps new contributors who run into the `Unsupported URL Type "workspace:*"` error when using `npm install`. It suggests using `bun` or `pnpm` as a solution.

This is based on real setup experience while trying to contribute to the repo.

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

- Manually verified the updated markdown renders correctly.
- No functional code change, so no runtime testing required.

**Test Configuration**:
* Node version: 18.x
* Browser: Brave (Chromium-based)
* Operating System: Windows 11

## Screenshots (if applicable)

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional context

Helps other new contributors avoid confusion and setup errors related to npm and monorepo workspace issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the contributing guide with a note advising users to upgrade npm or use bun or pnpm to resolve a common installation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->