### PR TITLE
fix: prevent unintended navigation on swipe

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -82,5 +82,6 @@
   }
   body {
     @apply bg-background text-foreground;
+    overscroll-behavior-x: contain;
   }
 }


### PR DESCRIPTION
## Description

This PR introduces a fix to prevent unintended browser navigation (back/forward) triggered by horizontal gestures such as:
- Touch edge-swipes on mobile
- Trackpad gestures on desktop

[Doc on usage of overscroll-behaviour-x](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior-x)

> The `contain` value disables native browser navigation, including the vertical pull-to-refresh gesture and horizontal swipe navigation.

Fixes #195 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Mobile device testing on Chrome
- [X] Desktop testing on Chrome

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules