### PR TITLE
fix(storage): add OPFS support check to prevent undefined getDirector…

### DIFF
--- a/apps/web/src/lib/storage/opfs-adapter.ts
+++ b/apps/web/src/lib/storage/opfs-adapter.ts
@@ -6,13 +6,19 @@ export class OPFSAdapter implements StorageAdapter<File> {
   constructor(directoryName: string = "media") {
     this.directoryName = directoryName;
   }
-
+  
+  // will check first rather charsing directly
   private async getDirectory(): Promise<FileSystemDirectoryHandle> {
+    if (!OPFSAdapter.isSupported()) {
+      throw new Error("OPFS is not supported in this environment.");
+    }
+
     const opfsRoot = await navigator.storage.getDirectory();
     return await opfsRoot.getDirectoryHandle(this.directoryName, {
       create: true,
     });
   }
+
 
   async get(key: string): Promise<File | null> {
     try {


### PR DESCRIPTION
In browsers where navigator.storage.getDirectory() is not supported (e.g. Firefox, Safari, SSR/Node.js), calling it directly causes this runtime error:

This breaks the media upload and caching feature for users in unsupported environments.

Solution
Added a support check using the existing OPFSAdapter.isSupported() method. If OPFS is not supported, we now throw a clear error instead of crashing. This improves stability and prepares the app for future fallbacks (e.g. IndexedDB or in-memory storage).

Contribution Notes
1. Identified the issue in apps/web/src/lib/storage/opfs-adapter.ts.
2. Updated the getDirectory() method to include a browser compatibility guard.
3. Committed the change following conventional commit standards.
4. Tested in Chromium (success) and simulated the error path in Firefox.

Small suggestion: the repo could benefit from a more detailed CONTRIBUTING.md to help new contributors navigate the monorepo structure and development setup more easily.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling by providing a clear error message when OPFS is not supported in the current environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->