### PR TITLE
fix(auth): update better-auth baseURL to use HTTPS in production

### DIFF
--- a/packages/auth/src/client.ts
+++ b/packages/auth/src/client.ts
@@ -1,5 +1,8 @@
 import { createAuthClient } from "better-auth/react";
 
 export const { signIn, signUp, useSession } = createAuthClient({
-  baseURL: process.env.NEXT_PUBLIC_BETTER_AUTH_URL!,
-}); 
+  baseURL:
+    process.env.NODE_ENV === "production"
+      ? "https://opencut.app"
+      : "http://localhost:3000",
+});

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -23,7 +23,7 @@ export const auth = betterAuth({
     },
   },
   appName: "OpenCut",
-  trustedOrigins: ["http://localhost:3000"],
+  trustedOrigins: ["http://localhost:3000", "https://opencut.app"],
 });
 
 export type Auth = typeof auth;


### PR DESCRIPTION
## Bug Report

### Platform
- macOS 14.0, Windows 11

### Browser
- Chrome, Dia, Safari


### Current Behavior
The application is experiencing a mixed content error when trying to authenticate users on the production site. The browser blocks authentication requests because:

1. The production site is served over HTTPS (`https://opencut.app/`)
2. The `NEXT_PUBLIC_BETTER_AUTH_URL` environment variable is set to `http://opencut.app` (HTTP)
3. When the better-auth client tries to make requests to `http://opencut.app/api/auth/get-session`, the browser blocks it with the error:

```
Mixed Content: The page at 'https://opencut.app/' was loaded over HTTPS, but requested an insecure resource 'http://opencut.app/api/auth/get-session'. This request has been blocked; the content must be served over HTTPS.
```

This results in authentication features (sign in, sign up, session management) being completely broken in production, while working fine in local development.



Here's a suggested description for the "Expected Behavior" section:

### Expected Behavior
Authentication should work seamlessly in production without any mixed content errors. Specifically:

1. The better-auth client should make HTTPS requests to `https://opencut.app/api/auth/*` endpoints when running in production
2. Users should be able to sign in, sign up, and maintain their session without any browser security warnings or blocked requests
3. The authentication flow should work consistently across both development (HTTP) and production (HTTPS) environments
4. No mixed content errors should appear in the browser console when accessing authentication features

The auth baseURL should automatically use the appropriate protocol (HTTP for localhost, HTTPS for production) to ensure secure communication while maintaining functionality across all environments.




### Recurrence Probability
- Always


### Steps to Reproduce
1. Visit the production site at `https://opencut.app/`
2. Open browser Developer Tools (F12)
3. Navigate to the Network tab
4. Refresh the page or trigger any authentication-related action (sign in, sign up, or session check)
5. Observe the `get-session` call in the Network tab shows a request to `http://opencut.app/api/auth/get-session` (HTTP instead of HTTPS)
6. Check the Console tab to see the mixed content error blocking the request

**Expected network request:** `https://opencut.app/api/auth/get-session`  
**Actual network request:** `http://opencut.app/api/auth/get-session` (blocked by browser)

### Screenshots
![WhatsApp Image 2025-07-14 at 2 35 13 AM](https://github.com/user-attachments/assets/938bcc7f-2413-45e6-8925-e5c8c41e7340)


## Testing Notes
- Tested locally with HTTP (works)
- Code logic verified for HTTPS environment
- Cannot test on actual production due to lack of access to production secrets
- Requires maintainer testing in staging/production environment

### Environment

- Node.js 18+
- Bun (latest version)
- Docker (for local database)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication configuration to recognize both local and production environments.
  * Added "https://opencut.app" as a trusted origin for authentication requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->