### PR TITLE
feat: add modal to input project name before entering editor

### DIFF
--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -237,7 +237,7 @@ export default function ProjectsPage() {
       <CreateProjectDialog
         isOpen={isOpenCreateProjectDialog}
         onOpenChange={setIsOpenCreateProjectDialog}
-        onConfirm={handleCreateProject}
+        onConfirm={onComfirmCreateProject}
       />
       
     </div>

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -28,6 +28,7 @@ import { useProjectStore } from "@/stores/project-store";
 import { useRouter } from "next/navigation";
 import { DeleteProjectDialog } from "@/components/delete-project-dialog";
 import { RenameProjectDialog } from "@/components/rename-project-dialog";
+import { CreateProjectDialog } from "@/components/create-project-dialog";
 
 export default function ProjectsPage() {
   const {
@@ -43,9 +44,11 @@ export default function ProjectsPage() {
     new Set()
   );
   const [isBulkDeleteDialogOpen, setIsBulkDeleteDialogOpen] = useState(false);
+  const [isOpenCreateProjectDialog, setIsOpenCreateProjectDialog] =
+    useState(false);
 
-  const handleCreateProject = async () => {
-    const projectId = await createNewProject("New Project");
+  const handleCreateProject = async (projectName: string) => {
+    const projectId = await createNewProject(projectName);
     console.log("projectId", projectId);
     router.push(`/editor/${projectId}`);
   };
@@ -81,6 +84,11 @@ export default function ProjectsPage() {
     setIsSelectionMode(false);
     setIsBulkDeleteDialogOpen(false);
   };
+
+  const onComfirmCreateProject = async (projectName: string) => {
+    setIsOpenCreateProjectDialog(false);
+    await handleCreateProject(projectName);
+  }
 
   const allSelected =
     savedProjects.length > 0 && selectedProjects.size === savedProjects.length;
@@ -120,7 +128,7 @@ export default function ProjectsPage() {
               )}
             </div>
           ) : (
-            <CreateButton onClick={handleCreateProject} />
+            <CreateButton onClick={() => setIsOpenCreateProjectDialog(true)} />
           )}
         </div>
       </div>
@@ -166,7 +174,7 @@ export default function ProjectsPage() {
                 >
                   Select Projects
                 </Button>
-                <CreateButton onClick={handleCreateProject} />
+                <CreateButton onClick={() => setIsOpenCreateProjectDialog(true)} />
               </div>
             )}
           </div>
@@ -204,7 +212,7 @@ export default function ProjectsPage() {
             <Loader2 className="h-8 w-8 text-muted-foreground animate-spin" />
           </div>
         ) : savedProjects.length === 0 ? (
-          <NoProjects onCreateProject={handleCreateProject} />
+          <NoProjects onCreateProject={() => setIsOpenCreateProjectDialog(true)} />
         ) : (
           <div className="grid grid-cols-1 xs:grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6">
             {savedProjects.map((project) => (
@@ -225,6 +233,13 @@ export default function ProjectsPage() {
         onOpenChange={setIsBulkDeleteDialogOpen}
         onConfirm={handleBulkDelete}
       />
+
+      <CreateProjectDialog
+        isOpen={isOpenCreateProjectDialog}
+        onOpenChange={setIsOpenCreateProjectDialog}
+        onConfirm={handleCreateProject}
+      />
+      
     </div>
   );
 }

--- a/apps/web/src/components/create-project-dialog.tsx
+++ b/apps/web/src/components/create-project-dialog.tsx
@@ -43,6 +43,7 @@ export function CreateProjectDialog({
             }
           }}
           onChange={(e) => setProjectName(e.target.value)}
+          value={projectName}
         />
         <DialogFooter>
           <Button
@@ -55,7 +56,7 @@ export function CreateProjectDialog({
           >
             Cancel
           </Button>
-          <Button variant="destructive" onClick={() => onConfirm(projectName)}>
+          <Button onClick={() => onConfirm(projectName)}>
             Create
           </Button>
         </DialogFooter>

--- a/apps/web/src/components/create-project-dialog.tsx
+++ b/apps/web/src/components/create-project-dialog.tsx
@@ -1,0 +1,65 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "./ui/input";
+import { useState } from "react";
+
+export function CreateProjectDialog({
+  isOpen,
+  onOpenChange,
+  onConfirm,
+}: {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (projectName: string) => void;
+}) {
+  const [projectName, setProjectName] = useState("New project");
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>Create Project</DialogTitle>
+          <DialogDescription>
+            Enter a name for your new project.
+          </DialogDescription>
+        </DialogHeader>
+        <Input 
+          autoFocus
+          placeholder="Project name"
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              onConfirm(e.currentTarget.value);
+            }
+          }}
+          onChange={(e) => setProjectName(e.target.value)}
+        />
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onOpenChange(false);
+            }}
+          >
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={() => onConfirm(projectName)}>
+            Create
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Description

This pull request adds a modal dialog to prompt the user to input a project name before navigating to the editor. Previously, clicking "New Project" would immediately enter the editor without giving the user the option to name their project.

This improves user experience by making the project creation process more intentional and organized.

Fixes: No issue opened yet (feature proposal)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manual test:

- [x] Go to `/projects`
- [x] Click on "New Project"
- [x] Modal appears asking for project name
- [x] After entering a valid name and confirming, the editor opens

**Test Configuration**:
* Node version: 20.x
* Browser (if applicable): Chrome 125+
* Operating System: Windows 10 / WSL2 Ubuntu 22.04

## Screenshots (if applicable)

<img width="500" src="https://res.cloudinary.com/dgkgppcom/image/upload/v1752551342/opencut_create_project_esv5jm.png" />

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (n/a)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my feature works (no test added yet)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

This change improves UX by encouraging users to name their projects explicitly during creation, and may help with organizing saved projects later.

---

Let me know if you'd like me to split this into smaller PRs or improve it further.
