### PR TITLE
feat: add Discord link to footer

### DIFF
--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -3,7 +3,7 @@
 import { motion } from "motion/react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { RiGithubLine, RiTwitterXLine } from "react-icons/ri";
+import { RiDiscordFill, RiGithubLine, RiTwitterXLine } from "react-icons/ri";
 import { getStars } from "@/lib/fetch-github-stars";
 import Image from "next/image";
 
@@ -58,6 +58,14 @@ export function Footer() {
                 rel="noopener noreferrer"
               >
                 <RiTwitterXLine className="h-5 w-5" />
+              </Link>
+              <Link
+                href="https://discord.com/invite/Mu3acKZvCp"
+                className="text-muted-foreground hover:text-foreground transition-colors"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <RiDiscordFill className="h-5 w-5" />
               </Link>
             </div>
           </div>


### PR DESCRIPTION
## Description

This pull request adds a Discord icon with the link (https://discord.com/invite/Mu3acKZvCp) to the community server in the website's footer. The icon is placed next to the existing GitHub and X links to maintain consistency. The react-icons library was used to add the icon.

Fixes # (issue)
This does not fix any existing issues.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The changes were verified manually by running the application locally.
1. Start the development server with `bun run dev`.
2. Open a web browser and navigate to `http://localhost:3000`.
3. Scroll down to the footer and confirm the Discord icon is visible next to the GitHub and X icons.
4. Click the Discord icon and verify it correctly links to the invite URL.

**Test Configuration**:
* Node version: v22.16.0
* Browser (if applicable): Arc Browser
* Operating System: MacOS 26 Tahoe

## Screenshots (if applicable)

<img width="395" height="165" alt="CleanShot 2025-07-15 at 19 38 44" src="https://github.com/user-attachments/assets/7c4db267-6aa9-4ad8-9773-fdaa9252b031" />

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Additional context

None.