### PR TITLE
fix: adjust padding on projects page

### DIFF
--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -326,7 +326,7 @@ function ProjectCard({
               </div>
             </div>
 
-            <CardContent className="px-0 pt-5 flex flex-col gap-1">
+            <CardContent className="pr-4 pl-3 pt-5 flex flex-col gap-1">
               <div className="flex items-start justify-between">
                 <h3 className="font-medium text-sm leading-snug group-hover:text-foreground/90 transition-colors line-clamp-2">
                   {project.name}
@@ -433,7 +433,7 @@ function ProjectCard({
               </div>
             </div>
 
-            <CardContent className="px-0 pt-5 flex flex-col gap-1">
+            <CardContent className="pr-4 pl-3 pt-5 flex flex-col gap-1">
               <div className="flex items-start justify-between">
                 <h3 className="font-medium text-sm leading-snug group-hover:text-foreground/90 transition-colors line-clamp-2">
                   {project.name}


### PR DESCRIPTION
## Description

This commit adjusts the padding for the project card component on the projects page. The left padding has been set to 12px to make 

Fixes # (issue)

No existing issues were fixed.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This change has been tested by visually inspecting the project card component on the projects page after applying the padding adjustments.

**Test Configuration**:
* Node version: v22.16.0
* Browser (if applicable): Arc Browser
* Operating System: MacOS 26 Tahoe

## Screenshots (if applicable)

Before:
<img width="289" height="391" alt="CleanShot 2025-07-15 at 22 28 55" src="https://github.com/user-attachments/assets/059f89cf-de39-40ed-b5f3-17158933e16c" />
After:
<img width="303" height="413" alt="CleanShot 2025-07-15 at 22 28 24" src="https://github.com/user-attachments/assets/1706fa93-3a0b-46de-a7cf-d0edcb240cbf" />


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated horizontal padding inside project cards for improved spacing and visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->