### PR TITLE
chore: add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ node_modules
 
 .cursor/
 bun.lockb
+
+# mac
+.DS_Store


### PR DESCRIPTION
This PR adds `.DS_Store` to the `.gitignore` file to avoid committing macOS system files.