### PR TITLE
Update README and contributing guidelines for clarity

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,6 +4,17 @@ Thank you for your interest in contributing to OpenCut! This document provides g
 
 ## Getting Started
 
+### Prerequisites
+
+- [Node.js](https://nodejs.org/en/) (v18 or later)
+- [Bun](https://bun.sh/docs/installation)
+  (for `npm` alternative)
+- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)
+
+> **Note:** Docker is optional, but it's essential for running the local database and Redis services. If you're planning to contribute to frontend features, you can skip the Docker setup. If you have followed the steps below in [Setup](#setup), you're all set to go!
+
+### Setup
+
 1. Fork the repository
 2. Clone your fork locally
 3. Navigate to the web app directory: `cd apps/web`
@@ -52,14 +63,6 @@ The current HTML-based preview is essentially a prototype - the binary approach 
 If you're unsure whether your idea falls into the preview category, feel free to ask us [directly in discord](https://discord.gg/zmR9N35cjK) or create a GitHub issue!
 
 ## Development Setup
-
-### Prerequisites
-
-- Node.js 18+
-- Bun (latest version)
-- Docker (for local database)
-
-> **Note:** Docker is optional, but it's essential for running the local database and Redis services. If you're planning to contribute to frontend features, you can skip the Docker setup. If you have followed the steps above in [Getting Started](#getting-started), you're all set to go!
 
 ### Local Development
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,6 +18,7 @@ Thank you for your interest in contributing to OpenCut! This document provides g
 ## What to Focus On
 
 **🎯 Good Areas to Contribute:**
+
 - Timeline functionality and UI improvements
 - Project management features
 - Performance optimizations
@@ -26,6 +27,7 @@ Thank you for your interest in contributing to OpenCut! This document provides g
 - Documentation and testing
 
 **⚠️ Areas to Avoid:**
+
 - Preview panel enhancements (text fonts, stickers, effects)
 - Export functionality improvements
 - Preview rendering optimizations

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,8 +7,22 @@ Thank you for your interest in contributing to OpenCut! This document provides g
 1. Fork the repository
 2. Clone your fork locally
 3. Navigate to the web app directory: `cd apps/web`
-4. Install dependencies: `bun install`
-5. Start the development server: `bun run dev`
+4. Copy `.env.example` to `.env.local`:
+
+   ```bash
+   # Unix/Linux/Mac
+   cp .env.example .env.local
+
+   # Windows Command Prompt
+   copy .env.example .env.local
+
+   # Windows PowerShell
+   Copy-Item .env.example .env.local
+   ```
+
+5. Install dependencies: `bun install`
+
+6. Start the development server: `bun run dev`
 
 > **Note:** If you see an error like `Unsupported URL Type "workspace:*"` when running `npm install`, you have two options:
 >

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,7 +21,6 @@ Thank you for your interest in contributing to OpenCut! This document provides g
    ```
 
 5. Install dependencies: `bun install`
-
 6. Start the development server: `bun run dev`
 
 > **Note:** If you see an error like `Unsupported URL Type "workspace:*"` when running `npm install`, you have two options:
@@ -59,6 +58,8 @@ If you're unsure whether your idea falls into the preview category, feel free to
 - Node.js 18+
 - Bun (latest version)
 - Docker (for local database)
+
+> **Note:** Docker is optional, but it's essential for running the local database and Redis services. If you're planning to contribute to frontend features, you can skip the Docker setup. If you have followed the steps above in [Getting Started](#getting-started), you're all set to go!
 
 ### Local Development
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,22 @@ If you're working on the UI/frontend and don't need authentication or database f
 1. Fork the repository
 2. Clone your fork locally
 3. Navigate to the web app directory: `cd apps/web`
-4. Install dependencies: `bun install`
-5. Start the development server: `bun dev`
+4. Copy `.env.example` to `.env.local`:
+
+   ```bash
+   # Unix/Linux/Mac
+   cp .env.example .env.local
+
+   # Windows Command Prompt
+   copy .env.example .env.local
+
+   # Windows PowerShell
+   Copy-Item .env.example .env.local
+   ```
+
+5. Install dependencies: `bun install`
+
+6. Start the development server: `bun dev`
 
 The application will be available at [http://localhost:3000](http://localhost:3000).
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,15 @@
 Before you begin, ensure you have the following installed on your system:
 
 - [Bun](https://bun.sh/docs/installation)
-- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)
 - [Node.js](https://nodejs.org/en/) (for `npm` alternative)
 
-### Setup
+**Additional requirements for full-stack development:**
+
+- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) (only needed for database/auth features)
+
+### Frontend-only Development (Recommended for UI work)
+
+If you're working on the UI/frontend and don't need authentication or database features:
 
 1. Fork the repository
 2. Clone your fork locally
@@ -51,15 +56,13 @@ Before you begin, ensure you have the following installed on your system:
 4. Install dependencies: `bun install`
 5. Start the development server: `bun dev`
 
-## Development Setup
+The application will be available at [http://localhost:3000](http://localhost:3000).
 
-### Prerequisites
+**Note:** This setup runs without Docker and is perfect for frontend development, UI improvements, and most feature work.
 
-- Node.js 18+
-- Bun (latest version)
-- Docker (for local database)
+### Full Development Setup (Database + Auth)
 
-### Local Development
+Only follow this if you need to work with authentication, user accounts, or database features.
 
 1. Start the database and Redis services:
 

--- a/README.md
+++ b/README.md
@@ -39,16 +39,14 @@
 
 Before you begin, ensure you have the following installed on your system:
 
+- [Node.js](https://nodejs.org/en/) (v18 or later)
 - [Bun](https://bun.sh/docs/installation)
-- [Node.js](https://nodejs.org/en/) (for `npm` alternative)
+  (for `npm` alternative)
+- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)
 
-**Additional requirements for full-stack development:**
+> **Note:** Docker is optional, but it's essential for running the local database and Redis services. If you're planning to run the frontend or want to contribute to frontend features, you can skip the Docker setup. If you have followed the steps below in [Setup](#setup), you're all set to go!
 
-- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) (only needed for database/auth features)
-
-### Frontend-only Development (Recommended for UI work)
-
-If you're working on the UI/frontend and don't need authentication or database features:
+### Setup
 
 1. Fork the repository
 2. Clone your fork locally
@@ -67,16 +65,11 @@ If you're working on the UI/frontend and don't need authentication or database f
    ```
 
 5. Install dependencies: `bun install`
-
 6. Start the development server: `bun dev`
 
-The application will be available at [http://localhost:3000](http://localhost:3000).
+## Development Setup
 
-**Note:** This setup runs without Docker and is perfect for frontend development, UI improvements, and most feature work.
-
-### Full Development Setup (Database + Auth)
-
-Only follow this if you need to work with authentication, user accounts, or database features.
+### Local Development
 
 1. Start the database and Redis services:
 


### PR DESCRIPTION
Enhance the clarity of the setup instructions for both frontend-only and full development environments in the README and contributing guidelines. This will help streamline the onboarding process for new contributors.

Why?

Refer to issue #281 #231. Many users are confused about how to get started with running the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified and separated setup instructions for frontend-only and full-stack development in both the contributing guide and README.
  * Added step-by-step guidance for copying environment files, including platform-specific commands.
  * Included Redis in the full-stack development prerequisites.
  * Provided clear recommendations on when to use each setup, improving onboarding for new contributors.
  * Improved formatting and reorganized prerequisite information to enhance readability and reduce redundancy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->