### PR TITLE
feat: display all contributors

### DIFF
--- a/apps/web/src/app/contributors/page.tsx
+++ b/apps/web/src/app/contributors/page.tsx
@@ -32,7 +32,7 @@ interface Contributor {
 async function getContributors(): Promise<Contributor[]> {
   try {
     const response = await fetch(
-      "https://api.github.com/repos/OpenCut-app/OpenCut/contributors",
+      "https://api.github.com/repos/OpenCut-app/OpenCut/contributors?per_page=100",
       {
         headers: {
           Accept: "application/vnd.github.v3+json",


### PR DESCRIPTION
## Description

This change updates the contributors page to display up to 100 contributors from the GitHub repository, an increase from the API's default of 30. This is achieved by adding the per_page=100 query parameter to the GitHub API request in contributors/page.tsx.

Fixes # (issue)

No existing issues were fixed.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I have verified these changes by running the application locally and navigating to the /contributors page.

Steps to reproduce:
1. Run the application locally `bun run dev`.
2. Open the browser and go to http://localhost:3000/contributors.
Confirm that the page now displays more than 30 contributors / 43 contributors as of 16th July 2025.

**Test Configuration**:
* Node version: v22.16.0
* Browser (if applicable): Arc Browser
* Operating System: MacOS 26 Tahoe

## Screenshots (if applicable)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

None.