### PR TITLE
fix: make tab bar container full width

### DIFF
--- a/apps/web/src/components/editor/media-panel/tabbar.tsx
+++ b/apps/web/src/components/editor/media-panel/tabbar.tsx
@@ -69,7 +69,7 @@ export function TabBar() {
       />
       <div
         ref={scrollContainerRef}
-        className="h-12 bg-panel-accent px-3 flex justify-start items-center gap-5 overflow-x-auto scrollbar-x-hidden relative"
+        className="h-12 bg-panel-accent px-3 flex justify-start items-center gap-5 overflow-x-auto scrollbar-x-hidden relative w-full"
       >
         {(Object.keys(tabs) as Tab[]).map((tabKey) => {
           const tab = tabs[tabKey];


### PR DESCRIPTION
Adjust the tab bar container to utilize the full width of its parent.

| Old | New |
|---|---|
| ![Old Image](https://github.com/user-attachments/assets/b4bc53ad-40f5-461c-9a70-79d203a64fad) | ![New Image](https://github.com/user-attachments/assets/3ac7ff4b-661a-4b26-9d3a-6e8758f4044c) |


