### PR TITLE
fix: regenerate video thumbnails when a project is loaded

### DIFF
--- a/apps/web/src/stores/media-store.ts
+++ b/apps/web/src/stores/media-store.ts
@@ -213,6 +213,7 @@ export const useMediaStore = create<MediaStore>((set, get) => ({
 
     try {
       const mediaItems = await storageService.loadAllMediaItems(projectId);
+
       // Regenerate thumbnails for video items
       const updatedMediaItems = await Promise.all(
         mediaItems.map(async (item) => {

--- a/apps/web/src/stores/media-store.ts
+++ b/apps/web/src/stores/media-store.ts
@@ -213,7 +213,28 @@ export const useMediaStore = create<MediaStore>((set, get) => ({
 
     try {
       const mediaItems = await storageService.loadAllMediaItems(projectId);
-      set({ mediaItems });
+      // Regenerate thumbnails for video items
+      const updatedMediaItems = await Promise.all(
+        mediaItems.map(async (item) => {
+          if (item.type === "video" && item.file) {
+            try {
+              const { thumbnailUrl, width, height } = await generateVideoThumbnail(item.file);
+              return {
+                ...item,
+                thumbnailUrl,
+                width: width || item.width,
+                height: height || item.height
+              };
+            } catch (error) {
+              console.error(`Failed to regenerate thumbnail for video ${item.id}:`, error);
+              return item;
+            }
+          }
+          return item;
+        })
+      );
+
+      set({ mediaItems: updatedMediaItems });
     } catch (error) {
       console.error("Failed to load media items:", error);
     } finally {


### PR DESCRIPTION
## Description

This change fixes the issue where video thumbnails are not being generated when loading a project, resulting in empty placeholders being shown instead of video previews. Currently the video thumbnails only generated when they are first uploaded but gone when refresh. I've thought of storing them in Storage but they may not be necessary since we only need to regenerate when loading a project.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Upload videos to the media view
- Refresh pages, they the thumbnail should be regenerated


**Test Configuration**:
* Node version: v22.11.0
* Browser (if applicable): Edge/Chrome
* Operating System: MacOs 

## Screenshots (if applicable)

Before:

<img width="1651" height="1356" alt="image" src="https://github.com/user-attachments/assets/e65eb135-bf60-4713-a3e0-0122b0c37480" />

After:

https://github.com/user-attachments/assets/278114ce-f86d-40eb-95df-4b9e81dc793f


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

Add any other context about the pull request here. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved video media handling by regenerating thumbnails for all video items after loading, ensuring updated and consistent thumbnail images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->