### PR TITLE
chore: add playhead to handlebars

### DIFF
--- a/apps/web/src/components/landing/handlebars.tsx
+++ b/apps/web/src/components/landing/handlebars.tsx
@@ -19,6 +19,8 @@ export function Handlebars({
   const [leftHandle, setLeftHandle] = useState(0);
   const [rightHandle, setRightHandle] = useState(maxWidth);
   const [contentWidth, setContentWidth] = useState(maxWidth);
+  const [playheadX, setPlayheadX] = useState(0);
+  const [showPlayhead, setShowPlayhead] = useState(false);
 
   const leftHandleX = useMotionValue(0);
   const rightHandleX = useMotionValue(maxWidth);
@@ -78,6 +80,26 @@ export function Handlebars({
       Math.min(contentWidth, rightHandle + info.offset.x)
     );
     setRightHandle(newRight);
+  };
+
+  const handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!containerRef.current) return;
+
+    const rect = containerRef.current.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const relativeX = x - leftHandle;
+
+    // Only show playhead if cursor is within the visible area
+    if (relativeX >= 0 && relativeX <= rightHandle - leftHandle) {
+      setPlayheadX(relativeX);
+      setShowPlayhead(true);
+    } else {
+      setShowPlayhead(false);
+    }
+  };
+
+  const handleMouseLeave = () => {
+    setShowPlayhead(false);
   };
 
   return (
@@ -146,6 +168,8 @@ export function Handlebars({
             x: leftHandleX,
             height: "100%",
           }}
+          onMouseMove={handleMouseMove}
+          onMouseLeave={handleMouseLeave}
         >
           <motion.div
             className="w-full h-full flex items-center justify-center px-4"
@@ -157,8 +181,25 @@ export function Handlebars({
           >
             {children}
           </motion.div>
+
+          {/* Playhead */}
+          <motion.div
+            className="absolute top-0 w-0.5 h-full bg-yellow-400 pointer-events-none z-20"
+            style={{
+              left: playheadX,
+            }}
+            initial={{ opacity: 0, scaleY: 0 }}
+            animate={{
+              opacity: showPlayhead ? 1 : 0,
+              scaleY: showPlayhead ? 1 : 0,
+            }}
+            transition={{
+              duration: 0.1,
+              ease: "easeOut",
+            }}
+          />
         </motion.div>
       </div>
     </div>
   );
-};
+}

--- a/apps/web/src/components/landing/handlebars.tsx
+++ b/apps/web/src/components/landing/handlebars.tsx
@@ -184,7 +184,7 @@ export function Handlebars({
 
           {/* Playhead */}
           <motion.div
-            className="absolute top-0 w-0.5 h-full bg-yellow-400 pointer-events-none z-20"
+            className="absolute top-0 w-0.5 h-full bg-primary pointer-events-none z-20"
             style={{
               left: playheadX,
             }}

--- a/apps/web/src/components/landing/hero.tsx
+++ b/apps/web/src/components/landing/hero.tsx
@@ -121,7 +121,7 @@ export function Hero() {
           transition={{ delay: 0.6, duration: 0.8 }}
           className="mb-8 flex justify-center"
         >
-          <SponsorButton 
+          <SponsorButton
             href="https://vercel.com/?utm_source=opencut"
             logo={VercelIcon}
             companyName="Vercel"
@@ -181,15 +181,15 @@ export function Hero() {
             </Button>
           </form>
         </motion.div>
-          <motion.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.8, duration: 0.6 }}
-            className="mt-8 inline-flex items-center gap-2 text-sm text-muted-foreground justify-center"
-          >
-            <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
-            <span>50k+ people already joined</span>
-          </motion.div>
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.8, duration: 0.6 }}
+          className="mt-8 inline-flex items-center gap-2 text-sm text-muted-foreground justify-center"
+        >
+          <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
+          <span>50k+ people already joined</span>
+        </motion.div>
       </motion.div>
     </div>
   );


### PR DESCRIPTION
Introduce a playhead to improve user interaction in the Handlebars component. It will be displayed when you hover over the component.

### Why? 
Looks cool maybe



https://github.com/user-attachments/assets/445d9326-7448-4b4f-a2a9-83ffbc293363

