### PR TITLE
feat: show skeletons while loading media thumbnails

### DIFF
--- a/apps/web/src/components/editor/media-panel/views/media.tsx
+++ b/apps/web/src/components/editor/media-panel/views/media.tsx
@@ -22,12 +22,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
 import { DraggableMediaItem } from "@/components/ui/draggable-item";
 import { useProjectStore } from "@/stores/project-store";
 import { useTimelineStore } from "@/stores/timeline-store";
 
 export function MediaView() {
-  const { mediaItems, addMediaItem, removeMediaItem } = useMediaStore();
+  const { mediaItems, addMediaItem, removeMediaItem, isLoading } = useMediaStore();
   const { activeProject } = useProjectStore();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isProcessing, setIsProcessing] = useState(false);
@@ -187,6 +188,39 @@ export function MediaView() {
       </div>
     );
   };
+
+  // render skeletons while loading media item thumbnails
+  if (isLoading) {
+    return (
+      <div className="h-full flex flex-col gap-1 transition-colors relative">
+        {/* Search and filter controls skeleton */}
+        <div className="p-3 pb-2">
+          <div className="flex gap-2">
+            <Skeleton className="w-[80px] h-8" /> {/* Filter dropdown */}
+            <Skeleton className="flex-1 h-8" /> {/* Search input */}
+          </div>
+        </div>
+
+        {/* Media grid skeleton */}
+        <div className="flex-1 overflow-y-auto p-3 pt-0">
+          <div
+            className="grid gap-2"
+            style={{
+              gridTemplateColumns: "repeat(auto-fill, 160px)",
+            }}
+          >
+            {/* 8 thumbnail skeletons */}
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className="flex flex-col gap-2 w-28 h-28">
+                <Skeleton className="w-full aspect-video" />
+                <Skeleton className="w-full h-4" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
## Description

PR #323 introduced thumbnail regeneration on project load, which caused media items to initially appear empty. This PR addresses that by adding loading skeletons to improve the user experience.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Quick UI test has been performed

**Test Configuration**:
* Node version: 22.11.0
* Browser (if applicable): Edge
* Operating System: MacOS

## Screenshots

### Before

https://github.com/user-attachments/assets/75e66d39-546e-4042-92a7-d49a08b7f2cf

### After

https://github.com/user-attachments/assets/c902a24c-8e61-4bee-a85a-d8705879a879


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added screenshots if ui has been changed
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

Add any other context about the pull request here. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skeleton placeholders to the media panel to indicate loading state, providing a smoother user experience while media items are being fetched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->