### PR TITLE
use select-none to prevent text selection

### DIFF
--- a/apps/web/src/components/landing/handlebars.tsx
+++ b/apps/web/src/components/landing/handlebars.tsx
@@ -148,7 +148,7 @@ export function Handlebars({
           }}
         >
           <motion.div
-            className="w-full h-full flex items-center justify-center px-4"
+            className="w-full h-full flex items-center justify-center px-4 select-none"
             style={{
               x: contentLeft,
               width: contentWidth,


### PR DESCRIPTION
Make draggable handler by pass the user select text.

before

<img width="689" height="282" alt="image" src="https://github.com/user-attachments/assets/f43bf6eb-d26b-465b-b094-f724e319283d" />

after

<img width="673" height="387" alt="image" src="https://github.com/user-attachments/assets/218e2f02-dd3e-4588-b5e1-166266180d19" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Handlebars component to prevent text selection in a specific content area for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->