### PR TITLE
feat: track-by-track volume control

### DIFF
--- a/apps/web/src/components/editor/media-volume.tsx
+++ b/apps/web/src/components/editor/media-volume.tsx
@@ -1,0 +1,25 @@
+import { useMediaVolume } from "@/hooks/use-media-volume";
+import { TimelineTrack } from "@/types/timeline";
+
+interface MediaVolumeProps {
+  track: TimelineTrack,
+  timelineElementRef: React.RefObject<HTMLDivElement>
+}
+
+export function MediaVolume({
+  track,
+  timelineElementRef
+}: MediaVolumeProps) {
+  const { position, handleVolumeMouseDown } = useMediaVolume({
+    track,
+    timelineElementRef
+  })
+
+  return (
+    <div className="absolute z-10 w-full bg-foreground h-0.5 cursor-ns-resize" style={{
+      top: `${position}px`
+    }}
+    onMouseDown={handleVolumeMouseDown}
+    />
+  )
+}

--- a/apps/web/src/components/editor/preview-panel.tsx
+++ b/apps/web/src/components/editor/preview-panel.tsx
@@ -295,6 +295,7 @@ export function PreviewPanel() {
               trimStart={element.trimStart}
               trimEnd={element.trimEnd}
               clipDuration={element.duration}
+              volume={elementData.track.volume}
             />
           </div>
         );

--- a/apps/web/src/components/editor/preview-panel.tsx
+++ b/apps/web/src/components/editor/preview-panel.tsx
@@ -328,6 +328,7 @@ export function PreviewPanel() {
               trimEnd={element.trimEnd}
               clipDuration={element.duration}
               trackMuted={elementData.track.muted}
+              volume={elementData.track.volume}
             />
           </div>
         );

--- a/apps/web/src/components/editor/timeline-element.tsx
+++ b/apps/web/src/components/editor/timeline-element.tsx
@@ -239,7 +239,7 @@ export function TimelineElement({
       const tileWidth = tileHeight * TILE_ASPECT_RATIO;
 
       return (
-        <div className="w-full h-full flex items-center gap-2">
+        <div className="w-full h-full flex items-center gap-2" ref={timelineElementRef}>
           <div className="flex-1 h-full relative overflow-hidden">
             {/* Background with tiled thumbnails */}
             <div
@@ -279,6 +279,7 @@ export function TimelineElement({
               {element.name}
             </span>
           )}
+          <MediaVolume track={track} timelineElementRef={timelineElementRef} />
         </div>
       );
     }

--- a/apps/web/src/components/editor/timeline-element.tsx
+++ b/apps/web/src/components/editor/timeline-element.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Button } from "../ui/button";
 import {
   MoreVertical,
@@ -43,6 +43,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "../ui/context-menu";
+import { MediaVolume } from "./media-volume";
 
 export function TimelineElement({
   element,
@@ -68,6 +69,7 @@ export function TimelineElement({
   const { currentTime } = usePlaybackStore();
 
   const [elementMenuOpen, setElementMenuOpen] = useState(false);
+  const timelineElementRef = useRef<HTMLDivElement>(null);
 
   const {
     resizing,
@@ -284,14 +286,15 @@ export function TimelineElement({
     // Render audio element ->
     if (mediaItem.type === "audio") {
       return (
-        <div className="w-full h-full flex items-center gap-2">
-          <div className="flex-1 min-w-0">
+        <div className="w-full h-full flex items-center gap-2 relative" ref={timelineElementRef}>
+          <div className="flex-1 min-w-0 relative">
             <AudioWaveform
               audioUrl={mediaItem.url || ""}
               height={24}
               className="w-full"
             />
           </div>
+          <MediaVolume track={track} timelineElementRef={timelineElementRef} />
         </div>
       );
     }

--- a/apps/web/src/components/ui/audio-player.tsx
+++ b/apps/web/src/components/ui/audio-player.tsx
@@ -11,6 +11,7 @@ interface AudioPlayerProps {
   trimEnd: number;
   clipDuration: number;
   trackMuted?: boolean;
+  volume: number;
 }
 
 export function AudioPlayer({
@@ -21,9 +22,10 @@ export function AudioPlayer({
   trimEnd,
   clipDuration,
   trackMuted = false,
+  volume
 }: AudioPlayerProps) {
   const audioRef = useRef<HTMLAudioElement>(null);
-  const { isPlaying, currentTime, volume, speed, muted } = usePlaybackStore();
+  const { isPlaying, currentTime, speed, muted } = usePlaybackStore();
 
   // Calculate if we're within this clip's timeline range
   const clipEndTime = clipStartTime + (clipDuration - trimStart - trimEnd);

--- a/apps/web/src/components/ui/video-player.tsx
+++ b/apps/web/src/components/ui/video-player.tsx
@@ -11,6 +11,7 @@ interface VideoPlayerProps {
   trimStart: number;
   trimEnd: number;
   clipDuration: number;
+  volume: number;
 }
 
 export function VideoPlayer({
@@ -21,9 +22,10 @@ export function VideoPlayer({
   trimStart,
   trimEnd,
   clipDuration,
+  volume
 }: VideoPlayerProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
-  const { isPlaying, currentTime, volume, speed, muted } = usePlaybackStore();
+  const { isPlaying, currentTime, speed, muted } = usePlaybackStore();
 
   // Calculate if we're within this clip's timeline range
   const clipEndTime = clipStartTime + (clipDuration - trimStart - trimEnd);

--- a/apps/web/src/hooks/use-media-volume.ts
+++ b/apps/web/src/hooks/use-media-volume.ts
@@ -1,0 +1,73 @@
+import { useTimelineStore } from "@/stores/timeline-store"
+import { TimelineTrack } from "@/types/timeline"
+import { useCallback, useEffect, useState } from "react";
+
+const BAR_HEIGHT = 2
+
+interface UseMediaVolumeProps {
+  track: TimelineTrack,
+  timelineElementRef: React.RefObject<HTMLDivElement>
+}
+
+export function useMediaVolume({
+  track,
+  timelineElementRef,
+}: UseMediaVolumeProps) {
+  const { setTrackVolume } = useTimelineStore();
+
+  const [position, setPosition] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const updateVolumeAndPosition = useCallback((clientY: number) => {
+    const timelineElement = timelineElementRef.current;
+    if (!timelineElement) return;
+
+    const rect = timelineElement.getBoundingClientRect();
+    const y = clientY - rect.top;
+    const clampedY = Math.max(0, Math.min(y, (timelineElement.clientHeight-BAR_HEIGHT)));
+
+    setPosition(clampedY);
+
+    const volume = 1 - clampedY / (timelineElement.clientHeight-BAR_HEIGHT);
+    setTrackVolume(track.id, Math.max(0, Math.min(volume, 1)));
+
+  }, [setTrackVolume, track.id, timelineElementRef]);
+
+  const handleVolumeMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation(); // Prevents the timeline element from changing track
+    setIsDragging(true);
+    updateVolumeAndPosition(e.clientY);
+  }, [updateVolumeAndPosition]);
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDragging) return;
+      updateVolumeAndPosition(e.clientY);
+    };
+
+    const handleMouseUp = () => {
+      if (isDragging) setIsDragging(false);
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isDragging, updateVolumeAndPosition]);
+
+  useEffect(() => {
+    if (timelineElementRef.current) {
+      const height = timelineElementRef.current.clientHeight-BAR_HEIGHT
+      setPosition(height - track.volume * height)
+    }
+  }, [])
+
+  return {
+    position,
+    handleVolumeMouseDown,
+  };
+}

--- a/apps/web/src/stores/timeline-store.ts
+++ b/apps/web/src/stores/timeline-store.ts
@@ -114,6 +114,7 @@ interface TimelineStore {
     startTime: number
   ) => void;
   toggleTrackMute: (trackId: string) => void;
+  setTrackVolume: (trackId: string, volume: number) => void;
 
   // Split operations for elements
   splitElement: (
@@ -315,6 +316,7 @@ export const useTimelineStore = create<TimelineStore>((set, get) => {
         type,
         elements: [],
         muted: false,
+        volume: 0.5
       };
 
       updateTracksAndSave([...get()._tracks, newTrack]);
@@ -340,6 +342,7 @@ export const useTimelineStore = create<TimelineStore>((set, get) => {
         type,
         elements: [],
         muted: false,
+        volume: 0.5
       };
 
       const newTracks = [...get()._tracks];
@@ -556,6 +559,19 @@ export const useTimelineStore = create<TimelineStore>((set, get) => {
       );
     },
 
+    setTrackVolume: (trackId: string, volume: number) => {
+      if (volume < 0 || volume > 1) {
+        return
+      }
+
+      get().pushHistory();
+      updateTracksAndSave(
+        get()._tracks.map((track) =>
+          track.id === trackId ? { ...track, volume: volume } : track
+        )
+      );
+    },
+
     updateTextElement: (trackId, elementId, updates) => {
       get().pushHistory();
       updateTracksAndSave(
@@ -756,6 +772,7 @@ export const useTimelineStore = create<TimelineStore>((set, get) => {
             },
           ],
           muted: false,
+          volume: 0.5
         };
 
         updateTracksAndSave([...get()._tracks, newAudioTrack]);
@@ -943,7 +960,7 @@ export const useTimelineStore = create<TimelineStore>((set, get) => {
         },
         justFinishedDragging: true,
       });
-      
+
       setTimeout(() => {
         set({ justFinishedDragging: false });
       }, 50);

--- a/apps/web/src/types/timeline.ts
+++ b/apps/web/src/types/timeline.ts
@@ -83,6 +83,7 @@ export interface TimelineTrack {
   name: string;
   type: TrackType;
   elements: TimelineElement[];
+  volume: number;
   muted?: boolean;
   isMain?: boolean;
 }
@@ -118,6 +119,7 @@ export function ensureMainTrack(tracks: TimelineTrack[]): TimelineTrack[] {
       elements: [],
       muted: false,
       isMain: true,
+      volume: 0.5
     };
     return [mainTrack, ...tracks];
   }


### PR DESCRIPTION
## Description

The volume was previously applied globally across all tracks. This pull-request enable per-track volume control on audios and videos.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Tests

## How Has This Been Tested?

Manual testing

**Test Configuration**: 
* Node version: v24.3.0
* Browser (if applicable): Firefox
* Operating System: macOS Sequoia 15.5

## Screenshots (if applicable)

[Add screenshots to help explain your changes.](https://github.com/user-attachments/assets/a4118830-000d-4392-a68b-d1e23ba5239a)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added screenshots if ui has been changed
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

Add any other context about the pull request here. 
