### PR TITLE
fix: separate audio shortcut changed and added functionality of already existing function

### DIFF
--- a/apps/web/src/components/editor/timeline.tsx
+++ b/apps/web/src/components/editor/timeline.tsx
@@ -683,7 +683,7 @@ export function Timeline() {
                   <SplitSquareHorizontal className="h-4 w-4" />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>Separate audio (Ctrl+D)</TooltipContent>
+              <TooltipContent>Separate audio (Ctrl+Shift+D)</TooltipContent>
             </Tooltip>
             <Tooltip>
               <TooltipTrigger asChild>

--- a/apps/web/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/web/src/hooks/use-keyboard-shortcuts.ts
@@ -34,6 +34,7 @@ export const useKeyboardShortcuts = (
     setSelectedElements,
     removeElementFromTrack,
     splitElement,
+    separateAudio,
     addElementToTrack,
     snappingEnabled,
     toggleSnapping,
@@ -259,6 +260,26 @@ export const useKeyboardShortcuts = (
           });
         }
       },
+    },
+    {
+      id: "separate-audio",
+      keys: ["Cmd+Shift+D", "Ctrl+Shift+D"],
+      description: "Separate audio from video",
+      category: "Selection",
+      requiresSelection: true,
+      action: () => {
+        if (selectedElements.length !== 1) {
+          toast.error("Select exactly one media element to separate audio");
+          return;
+        }
+        const { trackId, elementId } = selectedElements[0];
+        const track = tracks.find((t) => t.id === trackId);
+        if (!track || track.type !== "media") {
+          toast.error("Select a media element to separate audio");
+          return;
+        }
+        separateAudio(trackId, elementId);
+      }
     },
 
     // History


### PR DESCRIPTION
## Description

Chenged shortcut for separate audio, and hoocked it with the separate audion funtion for it to work as expected right now

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] checked that it worked and did what it was supposed to with the shortcut

**Test Configuration**:
* Node version: v22.14.0
* Browser (if applicable): chrome
* Operating System: mac os

## Screenshots (if applicable)


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have added screenshots if ui has been changed
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

Add any other context about the pull request here. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new keyboard shortcut (Cmd+Shift+D / Ctrl+Shift+D) to separate audio from video for selected timeline elements.

* **Style**
  * Updated the tooltip for the "Separate audio" button to display the new keyboard shortcut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->