### PR TITLE
[REFACTOR]: replace GitHub icon with FontAwesome version in footer

### DIFF
--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -3,7 +3,8 @@
 import { motion } from "motion/react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { RiDiscordFill, RiGithubLine, RiTwitterXLine } from "react-icons/ri";
+import { RiDiscordFill, RiTwitterXLine } from "react-icons/ri";
+import { FaGithub } from "react-icons/fa6";
 import { getStars } from "@/lib/fetch-github-stars";
 import Image from "next/image";
 
@@ -49,7 +50,7 @@ export function Footer() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <RiGithubLine className="h-5 w-5" />
+                <FaGithub className="h-5 w-5" />
               </Link>
               <Link
                 href="https://x.com/OpenCutApp"


### PR DESCRIPTION
## Description

Changed the GitHub icon from RiGithub (Remix Icons) to FaGithub (Font Awesome) in the footer component to improve the visual appearance and consistency of the UI. The Font Awesome GitHub icon provides better visual clarity and aligns better with the overall design aesthetic.


## Type of change

- [x] Code refactoring


## How Has This Been Tested?

- [x] Visual testing - Verified the GitHub icon displays correctly in the footer
- [x] Responsive testing - Checked icon appearance across different screen sizes
- [x] Accessibility testing - Ensured the icon maintains proper contrast and accessibility

**Test Configuration**:
* Node version: 22.11.0
* Browser (if applicable): Comet
* Operating System: macOS


## Screenshots (if applicable)

<img width="458" height="190" alt="before" src="https://github.com/user-attachments/assets/49dca428-32b8-4c78-a55d-365ae6f3a379" />
<img width="394" height="173" alt="after" src="https://github.com/user-attachments/assets/2366d73c-aea1-4744-b73f-4480d1377479" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added screenshots if ui has been changed
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules