### PR TITLE
fix: marble env keys in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ Before you begin, ensure you have the following installed on your system:
    UPSTASH_REDIS_REST_TOKEN="example_token"
 
    # Marble Blog
-  MARBLE_WORKSPACE_KEY=cm6ytuq9x0000i803v0isidst # example organization key
-  MARBLE_API_URL=https://api.marblecms.com
+   MARBLE_WORKSPACE_KEY=cm6ytuq9x0000i803v0isidst # example organization key
+   MARBLE_API_URL=https://api.marblecms.com
 
    # Development
    NODE_ENV="development"


### PR DESCRIPTION
Quick fix for the marble env keys in the reamde

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated indentation for environment variable examples in the README for improved formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->