### PR TITLE
[FEATURE] Select layer when adding to the Timeline

### DIFF
--- a/apps/web/src/stores/timeline-store.ts
+++ b/apps/web/src/stores/timeline-store.ts
@@ -549,6 +549,8 @@ export const useTimelineStore = create<TimelineStore>((set, get) => {
             : track
         )
       );
+
+      get().selectElement(trackId, newElement.id);
     },
 
     removeElementFromTrack: (trackId, elementId) => {


### PR DESCRIPTION
## Description

This PR implements #398, wich consists in selecting the layer automatically when is added to the timeline.

This is especially useful for text layers, as you expect to edit the text content as you add into the track, instead of searching for it in the timeline.

## Type of change

- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Verified the selection when a text layer is added
- [x] Verified the selection when a media layer is added (audio, video and image)

**Test Configuration**:
* Node version: v22.13.0
* Browser: Chrome/Safari/Firefox
* Operating System: macOS/Windows/Linux

## Screenshots (if applicable)


https://github.com/user-attachments/assets/b88a3502-404c-435a-a0c0-96efca674be2



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added screenshots if ui has been changed
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly added elements to a track are now automatically selected in the timeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->