### PR TITLE
fix: resolve playhead disappearing during timeline scroll

### DIFF
--- a/apps/web/src/components/editor/timeline-playhead.tsx
+++ b/apps/web/src/components/editor/timeline-playhead.tsx
@@ -54,13 +54,8 @@ export function TimelinePlayhead({
   const timelineContainerHeight = timelineRef.current?.offsetHeight || 400;
   const totalHeight = timelineContainerHeight - 8; // 8px padding from edges
 
-  // Get dynamic track labels width, fallback to 0 if no tracks or no ref
-  const trackLabelsWidth =
-    tracks.length > 0 && trackLabelsRef?.current
-      ? trackLabelsRef.current.offsetWidth
-      : 0;
+  // Since playhead is now inside scrollable content, position directly without track labels offset
   const leftPosition =
-    trackLabelsWidth +
     playheadPosition * TIMELINE_CONSTANTS.PIXELS_PER_SECOND * zoomLevel;
 
   return (

--- a/apps/web/src/components/editor/timeline.tsx
+++ b/apps/web/src/components/editor/timeline.tsx
@@ -841,22 +841,6 @@ export function Timeline() {
         className="flex-1 flex flex-col overflow-hidden relative"
         ref={timelineRef}
       >
-        <TimelinePlayhead
-          currentTime={currentTime}
-          duration={duration}
-          zoomLevel={zoomLevel}
-          tracks={tracks}
-          seek={seek}
-          rulerRef={rulerRef}
-          rulerScrollRef={rulerScrollRef}
-          tracksScrollRef={tracksScrollRef}
-          trackLabelsRef={trackLabelsRef}
-          timelineRef={timelineRef}
-          playheadRef={playheadRef}
-          isSnappingToPlayhead={
-            showSnapIndicator && currentSnapPoint?.type === "playhead"
-          }
-        />
         <SnapIndicator
           snapPoint={currentSnapPoint}
           zoomLevel={zoomLevel}
@@ -1021,6 +1005,22 @@ export function Timeline() {
                   width: `${dynamicTimelineWidth}px`,
                 }}
               >
+                <TimelinePlayhead
+                  currentTime={currentTime}
+                  duration={duration}
+                  zoomLevel={zoomLevel}
+                  tracks={tracks}
+                  seek={seek}
+                  rulerRef={rulerRef}
+                  rulerScrollRef={rulerScrollRef}
+                  tracksScrollRef={tracksScrollRef}
+                  trackLabelsRef={trackLabelsRef}
+                  timelineRef={timelineRef}
+                  playheadRef={playheadRef}
+                  isSnappingToPlayhead={
+                    showSnapIndicator && currentSnapPoint?.type === "playhead"
+                  }
+                />
                 {tracks.length === 0 ? (
                   <div></div>
                 ) : (


### PR DESCRIPTION
## Problem
The playhead was disappearing when scrolling horizontally in the timeline, making it difficult to control playback position.

## Root Cause
The TimelinePlayhead component was rendered outside the scrollable content areas. When users scrolled, the timeline content moved inside ScrollArea components, but the playhead remained in its fixed position at the container level.

## Solution
- Moved TimelinePlayhead component inside the scrollable tracks content area
- Simplified positioning logic by removing trackLabelsWidth offset since playhead is now positioned directly within scrollable content
- Maintains all existing functionality (color, snapping, interaction)

## Changes
- [timeline.tsx](cci:7://file:///d:/OpenCutt/apps/web/src/components/editor/timeline.tsx:0:0-0:0): Relocated TimelinePlayhead from container level to inside ScrollArea
- [timeline-playhead.tsx](cci:7://file:///d:/OpenCutt/apps/web/src/components/editor/timeline-playhead.tsx:0:0-0:0): Simplified position calculation

## Testing
- [x] Playhead stays visible during horizontal scroll
- [x] Playhead color and snapping behavior unchanged
- [x] Timeline interaction and seeking still works
- [x] No breaking changes to existing functionality

**Before**

https://github.com/user-attachments/assets/cd24dce6-c854-41fc-b604-f09b79212bca

**After**

https://github.com/user-attachments/assets/eb8f4932-26bd-41b0-b7b4-28c7870f9d4b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted the timeline playhead to render inside the scrollable tracks area for improved alignment and scrolling behavior.
  * Simplified the playhead's horizontal positioning logic for more accurate placement within the timeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->