### PR TITLE
Title: fix(timeline): Ensure playhead scrolls with tracks

### DIFF
--- a/apps/web/src/components/editor/timeline/index.tsx
+++ b/apps/web/src/components/editor/timeline/index.tsx
@@ -513,22 +513,7 @@ export function Timeline() {
         className="flex-1 flex flex-col overflow-hidden relative"
         ref={timelineRef}
       >
-        <TimelinePlayhead
-          currentTime={currentTime}
-          duration={duration}
-          zoomLevel={zoomLevel}
-          tracks={tracks}
-          seek={seek}
-          rulerRef={rulerRef}
-          rulerScrollRef={rulerScrollRef}
-          tracksScrollRef={tracksScrollRef}
-          trackLabelsRef={trackLabelsRef}
-          timelineRef={timelineRef}
-          playheadRef={playheadRef}
-          isSnappingToPlayhead={
-            showSnapIndicator && currentSnapPoint?.type === "playhead"
-          }
-        />
+
         <SnapIndicator
           snapPoint={currentSnapPoint}
           zoomLevel={zoomLevel}
@@ -599,8 +584,8 @@ export function Timeline() {
                       <div
                         key={i}
                         className={`absolute top-0 bottom-0 ${isMainMarker
-                            ? "border-l border-muted-foreground/40"
-                            : "border-l border-muted-foreground/20"
+                          ? "border-l border-muted-foreground/40"
+                          : "border-l border-muted-foreground/20"
                           }`}
                         style={{
                           left: `${time * TIMELINE_CONSTANTS.PIXELS_PER_SECOND * zoomLevel}px`,
@@ -608,8 +593,8 @@ export function Timeline() {
                       >
                         <span
                           className={`absolute top-1 left-1 text-[0.6rem] ${isMainMarker
-                              ? "text-muted-foreground font-medium"
-                              : "text-muted-foreground/70"
+                            ? "text-muted-foreground font-medium"
+                            : "text-muted-foreground/70"
                             }`}
                         >
                           {(() => {
@@ -708,6 +693,22 @@ export function Timeline() {
                   width: `${dynamicTimelineWidth}px`,
                 }}
               >
+                <TimelinePlayhead
+                  currentTime={currentTime}
+                  duration={duration}
+                  zoomLevel={zoomLevel}
+                  tracks={tracks}
+                  seek={seek}
+                  rulerRef={rulerRef}
+                  rulerScrollRef={rulerScrollRef}
+                  tracksScrollRef={tracksScrollRef}
+                  trackLabelsRef={trackLabelsRef}
+                  timelineRef={timelineRef}
+                  playheadRef={playheadRef}
+                  isSnappingToPlayhead={
+                    showSnapIndicator && currentSnapPoint?.type === "playhead"
+                  }
+                />
                 {tracks.length === 0 ? (
                   <div></div>
                 ) : (

--- a/apps/web/src/components/editor/timeline/timeline-playhead.tsx
+++ b/apps/web/src/components/editor/timeline/timeline-playhead.tsx
@@ -54,13 +54,8 @@ export function TimelinePlayhead({
   const timelineContainerHeight = timelineRef.current?.offsetHeight || 400;
   const totalHeight = timelineContainerHeight - 8; // 8px padding from edges
 
-  // Get dynamic track labels width, fallback to 0 if no tracks or no ref
-  const trackLabelsWidth =
-    tracks.length > 0 && trackLabelsRef?.current
-      ? trackLabelsRef.current.offsetWidth
-      : 0;
+  // Since playhead is now inside scrollable content, position directly without track labels offset
   const leftPosition =
-    trackLabelsWidth +
     playheadPosition * TIMELINE_CONSTANTS.PIXELS_PER_SECOND * zoomLevel;
 
   return (


### PR DESCRIPTION
### `fix(timeline): Ensure playhead scrolls with tracks`

Closes #431

---

###  Description

This PR fixes a UI bug where the timeline playhead would not scroll along with the timeline tracks.
When a user scrolled the timeline horizontally, the playhead would remain in a fixed position and disappear from view, making it difficult to track the current playback time.

---

### ✅ Changes Made

* **Moved `TimelinePlayhead` component**
  The `TimelinePlayhead` component in
  `apps/web/src/components/editor/timeline/timeline-playhead.tsx`
  has been **moved from its parent container** into the **main scrollable area** that contains the timeline tracks.
  This ensures the playhead is part of the same scroll context.

* **Updated Position Calculation**
  The `leftPosition` logic in `timeline-playhead.tsx` has been updated to **remove the now-unnecessary offset**
  for the track labels — ensuring correct positioning within the scrollable container.



 **Before**

https://github.com/user-attachments/assets/28595f80-6a8a-4401-9946-02c9a56329c7

**After**

https://github.com/user-attachments/assets/c5a3c398-153d-4d1b-a3fa-aa128b6d2f77

Tested on my local system of windows 11 and latest chrome and brave browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted the placement of the timeline playhead to align with the scrollable tracks area, improving consistency during horizontal scrolling.
  * Simplified playhead positioning for more accurate alignment within the timeline.

* **Style**
  * Minor indentation and whitespace improvements for better code readability (no impact on functionality).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->