### PR TITLE
fix: left drag handle of timeline element 

### DIFF
--- a/apps/web/src/stores/timeline-store.ts
+++ b/apps/web/src/stores/timeline-store.ts
@@ -86,6 +86,7 @@ interface TimelineStore {
   updateElementTrim: (
     trackId: string,
     elementId: string,
+    startTime: number,
     trimStart: number,
     trimEnd: number
   ) => void;
@@ -467,7 +468,7 @@ export const useTimelineStore = create<TimelineStore>((set, get) => {
       updateTracksAndSave(newTracks);
     },
 
-    updateElementTrim: (trackId, elementId, trimStart, trimEnd) => {
+    updateElementTrim: (trackId, elementId, startTime, trimStart, trimEnd) => {
       get().pushHistory();
       updateTracksAndSave(
         get()._tracks.map((track) =>
@@ -476,7 +477,12 @@ export const useTimelineStore = create<TimelineStore>((set, get) => {
                 ...track,
                 elements: track.elements.map((element) =>
                   element.id === elementId
-                    ? { ...element, trimStart, trimEnd }
+                    ? {
+                        ...element,
+                        trimStart,
+                        trimEnd,
+                        startTime,
+                      }
                     : element
                 ),
               }


### PR DESCRIPTION
## Description
This PR includes fix for timeline element left drag handle.

Before:
moving left drag handle results in extension/compression of ending side

https://github.com/user-attachments/assets/28740f9c-a57d-4aef-8947-04784128d8c8

After:
left drag handle only affects the movement of starting side 

https://github.com/user-attachments/assets/0754a5ba-2121-45c0-a78c-1abe2eade5b4







Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Tests

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Node version:
* Browser (if applicable):
* Operating System:

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

Add any other context about the pull request here. 