### PR TITLE
fix: Added z-index in playhead so it doesnt appears above popups

### DIFF
--- a/apps/web/src/components/editor/timeline/timeline-playhead.tsx
+++ b/apps/web/src/components/editor/timeline/timeline-playhead.tsx
@@ -72,6 +72,7 @@ export function TimelinePlayhead({
         top: 0,
         height: `${totalHeight}px`,
         width: "2px", // Slightly wider for better click target
+        zIndex: 50,
       }}
       onMouseDown={handlePlayheadMouseDown}
     >

--- a/apps/web/src/components/editor/timeline/timeline-playhead.tsx
+++ b/apps/web/src/components/editor/timeline/timeline-playhead.tsx
@@ -72,7 +72,7 @@ export function TimelinePlayhead({
         top: 0,
         height: `${totalHeight}px`,
         width: "2px", // Slightly wider for better click target
-        zIndex: 50,
+        zIndex: 100,
       }}
       onMouseDown={handlePlayheadMouseDown}
     >


### PR DESCRIPTION
Before : 
<img width="1919" height="971" alt="Screenshot 2025-07-23 153251" src="https://github.com/user-attachments/assets/67afda42-fa1d-4917-9ca9-9f81ebeaf840" />

After : 
<img width="1919" height="967" alt="Screenshot 2025-07-23 153724" src="https://github.com/user-attachments/assets/c223ef6e-ae51-46d2-9ac8-1d1db860569b" />
<img width="1919" height="970" alt="Screenshot 2025-07-23 153257" src="https://github.com/user-attachments/assets/bd6f1b98-8312-4e96-a480-0e00ddb41423" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the visual stacking order of the timeline playhead for better visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->