### PR TITLE
Update PropertyItem component and frame rate dropdown to flex-col so label and value are not on the same line

### DIFF
--- a/apps/web/src/components/editor/properties-panel/index.tsx
+++ b/apps/web/src/components/editor/properties-panel/index.tsx
@@ -41,7 +41,7 @@ export function PropertiesPanel() {
           label="Resolution:"
           value={`${canvasSize.width} × ${canvasSize.height}`}
         />
-        <div className="flex justify-between items-center">
+        <div className="flex flex-col gap-1">
           <Label className="text-xs text-muted-foreground">Frame rate:</Label>
           <Select
             value={(activeProject?.fps || 30).toString()}
@@ -101,9 +101,9 @@ export function PropertiesPanel() {
 
 function PropertyItem({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex justify-between">
+    <div className="flex flex-col gap-1">
       <Label className="text-xs text-muted-foreground">{label}</Label>
-      <span className="text-xs text-right truncate w-40" title={value}>
+      <span className="text-xs break-words" title={value}>
         {value}
       </span>
     </div>


### PR DESCRIPTION
## Description

Updating the `PropertyItem` component and Frame Rate dropdown to `flex-col` to put the label and values on separate lines. This allows the value more room to display the text. Also, the class `break-words` was added to `PropertyItem` to wrap words to the next line

Fixes [429](https://github.com/OpenCut-app/OpenCut/issues/429)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Resized Properties panel
- Resized browser window below 1780 px

**Test Configuration**:
* Node version: v22.14.0
* Browser (if applicable): Chrome
* Operating System: Mac

## Screenshots (if applicable)

<img width="627" height="728" alt="Screenshot 2025-07-25 at 08 05 59" src="https://github.com/user-attachments/assets/2a3ec49e-d6cf-4876-9121-187f3497e1f0" />


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added screenshots if ui has been changed
- [x] My changes generate no new warnings



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the layout of the frame rate selector and property items in the Properties Panel to display vertically with improved spacing.
  * Enhanced text display for property values to support word wrapping, improving readability for longer content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->