### PR TITLE
fix: preserve line breaks in text element rendering

### DIFF
--- a/apps/web/src/components/editor/preview-panel.tsx
+++ b/apps/web/src/components/editor/preview-panel.tsx
@@ -277,7 +277,7 @@ export function PreviewPanel() {
               textDecoration: element.textDecoration,
               padding: "4px 8px",
               borderRadius: "2px",
-              whiteSpace: "nowrap",
+              whiteSpace: "pre-wrap",
               // Fallback for system fonts that don't have classes
               ...(fontClassName === "" && { fontFamily: element.fontFamily }),
             }}


### PR DESCRIPTION
- Change whiteSpace from 'nowrap' to 'pre-wrap' in preview panel
- Allows multi-line text content to display correctly
- Maintains existing text wrapping behavior

## Description

Fixed text rendering in the preview panel to properly display line breaks and whitespace. Previously, text elements with multiple lines would display as a single line due to `whiteSpace: 'nowrap'` CSS property. This change allows multi-line text content to display correctly while maintaining existing text wrapping behavior.

The fix changes the `whiteSpace` CSS property from `'nowrap'` to `'pre-wrap'` in the text element rendering function, which preserves line breaks and spaces from the original text while allowing wrapping when necessary.

Fixes #448

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Tests

## How Has This Been Tested?

- [x] Manual testing with multi-line text elements in the preview panel
- [x] Verified that existing single-line text still renders correctly
- [x] Tested text wrapping behavior with long content
- [x] Confirmed no regression in text styling (font, color, alignment, etc.)

**Test Configuration**:
* Node version: 20
* Browser: Chrome
* Operating System: Arch Linux

## Screenshots (if applicable)

**Before (Issue):**
- Multi-line text displayed as single line
- Line breaks were ignored

**After (Fix):**
- Multi-line text displays with proper line breaks
- Whitespace is preserved as expected
<img width="809" height="423" alt="image" src="https://github.com/user-attachments/assets/caf00cdc-8240-4e12-9014-241ad9659dc5" />

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added screenshots if ui has been changed
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

This is a minimal, focused fix that addresses a specific rendering issue without affecting other functionality. The change from `whiteSpace: 'nowrap'` to `whiteSpace: 'pre-wrap'` is a standard CSS solution for preserving line breaks while allowing text wrapping when needed.

The fix maintains backward compatibility and doesn't introduce any breaking changes to existing text elements.