### PR TITLE
fix: prevent new project show old media in initial load

### DIFF
--- a/apps/web/src/app/editor/[project_id]/page.tsx
+++ b/apps/web/src/app/editor/[project_id]/page.tsx
@@ -32,39 +32,28 @@ export default function Editor() {
     setPropertiesPanel,
   } = usePanelStore();
 
-  const { activeProject, loadProject, createNewProject } = useProjectStore();
+  const { loadProject } = useProjectStore();
   const params = useParams();
   const router = useRouter();
   const projectId = params.project_id as string;
-  const handledProjectIds = useRef<Set<string>>(new Set());
 
   usePlaybackControls();
 
   useEffect(() => {
     const initProject = async () => {
-      if (!projectId) return;
-
-      if (activeProject?.id === projectId) {
-        return;
-      }
-
-      if (handledProjectIds.current.has(projectId)) {
-        return;
-      }
-
       try {
         await loadProject(projectId);
-      } catch (error) {
-        handledProjectIds.current.add(projectId);
-
-        const newProjectId = await createNewProject("Untitled Project");
-        router.replace(`/editor/${newProjectId}`);
+      } catch (error: any) {
+        // if the project is not found, go back to the projects page
+        if (error.message.includes("not found")) {
+          router.push("/projects");
+        }
         return;
       }
     };
 
     initProject();
-  }, [projectId, activeProject?.id, loadProject, createNewProject, router]);
+  }, [projectId, loadProject, router]);
 
   return (
     <EditorProvider>


### PR DESCRIPTION
## Description

- When a new project is created, it show old media and timeline in initial load.
- This was fixed in #341, probably lost in merge conflict

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?


**Test Configuration**:
* Node version:
* Browser (if applicable):
* Operating System:

## Screenshots (if applicable)

### Before

https://github.com/user-attachments/assets/ce526d85-3aaa-4911-af49-2815e4c30abc

### After

https://github.com/user-attachments/assets/f3edce8f-d028-4d41-87dd-09798e922304



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added screenshots if ui has been changed
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

Add any other context about the pull request here. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when loading a project fails; users are now redirected to the projects page if the project is not found, instead of creating a new project.
* **Refactor**
  * Simplified project loading logic for better reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->