### PR TITLE
Feature: allow media resize controls

### DIFF
--- a/apps/web/src/components/ui/draggable-item.tsx
+++ b/apps/web/src/components/ui/draggable-item.tsx
@@ -125,13 +125,14 @@ export function DraggableMediaItem({
           </AspectRatio>
           {showLabel && (
             <span
-              className="text-[0.7rem] text-muted-foreground truncate w-full text-left"
+              className="text-[0.7rem] text-muted-foreground w-full text-left flex"
               aria-label={name}
               title={name}
             >
-              {name.length > 8
-                ? `${name.slice(0, 16)}...${name.slice(-3)}`
-                : name}
+              <span className="truncate max-w-full">
+                {name.slice(0, name.length - 4)}
+              </span>
+              {name.slice(-4)}
             </span>
           )}
         </div>

--- a/apps/web/src/components/ui/draggable-item.tsx
+++ b/apps/web/src/components/ui/draggable-item.tsx
@@ -24,6 +24,10 @@ export interface DraggableMediaItemProps {
   showPlusOnDrag?: boolean;
   showLabel?: boolean;
   rounded?: boolean;
+  /**
+   * media item size
+   */
+  size?: number;
 }
 
 export function DraggableMediaItem({
@@ -37,6 +41,7 @@ export function DraggableMediaItem({
   showPlusOnDrag = true,
   showLabel = true,
   rounded = true,
+  size,
 }: DraggableMediaItemProps) {
   const [isDragging, setIsDragging] = useState(false);
   const [dragPosition, setDragPosition] = useState({ x: 0, y: 0 });
@@ -88,7 +93,14 @@ export function DraggableMediaItem({
 
   return (
     <>
-      <div ref={dragRef} className="relative group w-28 h-28">
+      <div
+        ref={dragRef}
+        className={cn(
+          "relative group",
+          // size is provided for resizeable items, fill the width in that case
+          size ? "size-full" : "size-28"
+        )}
+      >
         <div
           className={`flex flex-col gap-1 p-0 h-auto w-full relative cursor-default ${className}`}
         >


### PR DESCRIPTION
## Description

- Added size controls to the media panel with 5 adjustable levels and localStorage persistence. Users can now zoom in/out using buttons or a slider to customize their media item viewing experience. The grid layout automatically adjusts to provide optimal space utilization at each size level.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

UI test has been performed

**Test Configuration**:
* Node version: v22.11.0
* Browser (if applicable): Edge
* Operating System: MacOS

## Screenshots (if applicable)

https://github.com/user-attachments/assets/3c8934aa-2d4a-4681-bc52-c900e70bdc13

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added screenshots if ui has been changed
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

