### PR TITLE
Fix: Prevent Ctrl+A from selecting timeline when input is focused

### DIFF
--- a/apps/web/src/hooks/use-keybindings.ts
+++ b/apps/web/src/hooks/use-keybindings.ts
@@ -24,6 +24,15 @@ export function useKeybindingsListener() {
       const boundAction = keybindings[binding];
       if (!boundAction) return;
 
+      const activeElement = document.activeElement;
+      const isTextInput =
+        activeElement &&
+        (activeElement.tagName === "INPUT" ||
+          activeElement.tagName === "TEXTAREA" ||
+          (activeElement as HTMLElement).isContentEditable);
+
+      if (isTextInput) return;
+
       ev.preventDefault();
 
       // Handle actions with default arguments


### PR DESCRIPTION
## Description

This PR fixes a bug where pressing CTRL+A selects all objects on the timeline even when the focus is on a text field. Now, if a text input is focused, CTRL+A will only select the content within the input and  not the entire timeline.


Fixes #462


## Type of change

- [✅ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

This fix was tested manually by:
- Creating a project.
- Adding a video and a text object to the timeline.
- Selecting the text object.
- Clicking into the text field on the right panel.
- Pressing CTRL+A to ensure only the text inside the input was selected and not the entire timeline.


**Test Configuration**:
* Node version: (same as project default)
* Browser: Brave v 1.80.124
* Operating System: Windows 11


## Checklist:

- [✅] My code follows the style guidelines of this project
- [✅ ] I have performed a self-review of my code
- [ ✅] My changes generate no new warnings


## Additional context

Previously, pressing Ctrl + A while a text field was focused would select all elements on the timeline.
This fix ensures that when a text input is focused, Ctrl + A will only select the text inside that field.
The implementation checks whether the currently focused element is a text input or textarea before applying the shortcut behavior.