### PR TITLE
Fix: show project card's dropdown menu by default (without hover)

### DIFF
--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -446,11 +446,7 @@ function ProjectCard({
                 <Button
                   variant="text"
                   size="sm"
-                  className={`size-6 p-0 transition-all shrink-0 ml-2 ${
-                    isDropdownOpen
-                      ? "opacity-100"
-                      : "opacity-0 group-hover:opacity-100"
-                  }`}
+                  className={`size-6 p-0 transition-all shrink-0 ml-2`}
                   onClick={(e) => e.preventDefault()}
                 >
                   <MoreHorizontal />


### PR DESCRIPTION
## Description

This PR addresses an accessibility issue where the project card's dropdown menu was only visible on hover. This behavior made the menu inaccessible for keyboard-only users and Mobile and touchscreen users (which lack a hover state)

Fixes # (issue)
#475 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

✅Manually tested with keyboard navigation (Tab, Shift+Tab, Enter)
✅Tested mouse interaction and confirmed dropdown appears as expected
✅Verified behavior on mobile (touch) 

**Test Configuration**:
* Node version: 22.14.0
* Browser (if applicable): Firefox Version 141.0
* Operating System: Windows 10

## Screenshots (if applicable)

<img width="335" height="391" alt="image" src="https://github.com/user-attachments/assets/1f79a7c7-d62f-4698-b2a4-aa6cfcab4a76" />

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added screenshots if ui has been changed
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the "More Options" button in project cards to remain consistently visible, improving clarity and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->