### PR TITLE
refactor: fix zoom constants hardcoded

### DIFF
--- a/apps/web/src/components/editor/timeline/index.tsx
+++ b/apps/web/src/components/editor/timeline/index.tsx
@@ -931,11 +931,11 @@ function TimelineToolbar({
 
   // Zoom handlers
   const handleZoomIn = () => {
-    setZoomLevel(Math.min(4, zoomLevel + 0.25));
+    setZoomLevel(Math.min(TIMELINE_CONSTANTS.MAX_ZOOM, zoomLevel + TIMELINE_CONSTANTS.ZOOM_STEP));
   };
 
   const handleZoomOut = () => {
-    setZoomLevel(Math.max(0.25, zoomLevel - 0.25));
+    setZoomLevel(Math.max(TIMELINE_CONSTANTS.MIN_ZOOM, zoomLevel - TIMELINE_CONSTANTS.ZOOM_STEP));
   };
 
   const handleZoomSliderChange = (values: number[]) => {
@@ -1111,9 +1111,9 @@ function TimelineToolbar({
             className="w-24"
             value={[zoomLevel]}
             onValueChange={handleZoomSliderChange}
-            min={0.25}
-            max={4}
-            step={0.25}
+            min={TIMELINE_CONSTANTS.MIN_ZOOM}
+            max={TIMELINE_CONSTANTS.MAX_ZOOM}
+            step={TIMELINE_CONSTANTS.ZOOM_STEP}
           />
           <Button variant="text" size="icon" onClick={handleZoomIn}>
             <ZoomIn className="h-4 w-4" />

--- a/apps/web/src/constants/timeline-constants.ts
+++ b/apps/web/src/constants/timeline-constants.ts
@@ -68,6 +68,9 @@ export function getTotalTracksHeight(
   return tracksHeight + gapsHeight;
 }
 
+// Zoom configuration
+const ZOOM_LEVELS = [0.25, 0.5, 1, 1.5, 2, 3, 4] as const;
+
 // Other timeline constants
 export const TIMELINE_CONSTANTS = {
   ELEMENT_MIN_WIDTH: 80,
@@ -75,7 +78,10 @@ export const TIMELINE_CONSTANTS = {
   TRACK_HEIGHT: 60, // Default fallback
   DEFAULT_TEXT_DURATION: 5,
   DEFAULT_IMAGE_DURATION: 5,
-  ZOOM_LEVELS: [0.25, 0.5, 1, 1.5, 2, 3, 4],
+  ZOOM_LEVELS,
+  MIN_ZOOM: ZOOM_LEVELS[0],
+  MAX_ZOOM: ZOOM_LEVELS[ZOOM_LEVELS.length - 1],
+  ZOOM_STEP: 0.25,
 } as const;
 
 // FPS presets for project settings


### PR DESCRIPTION
## Description
Change from using hardcoded zoom level constant 

Refactored timeline zoom functionality to use centralized constants instead of magic numbers. Replaced hardcoded values (0.25, 4, 0.25) in zoom handlers and slider configuration with TIMELINE_CONSTANTS.MIN_ZOOM, MAX_ZOOM, and ZOOM_STEP.

Fixes # (issue)

- Updated zoom in/out handlers to use constants
- Modified zoom slider min/max/step props to use constants
- Enhanced maintainability by centralizing zoom configuration
- No functional changes - zoom behavior remains identical.

## Type of change

- [ ] Code refactoring

## How Has This Been Tested?

This is just pure refactoring, no functional changes

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Checklist:

- [✓] My code follows the style guidelines of this project
- [✓] I have performed a self-review of my code
- [X] I have added screenshots if ui has been changed -> no ui changed
- [✓] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation -> small refactor
- [✓] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works -> small refactor
- [✓] New and existing unit tests pass locally with my changes
- [✓] Any dependent changes have been merged and published in downstream modules

