### PR TITLE
feat: add hide or show for media elements, mute or unmute for audio elements

### DIFF
--- a/apps/web/src/components/editor/preview-panel.tsx
+++ b/apps/web/src/components/editor/preview-panel.tsx
@@ -234,6 +234,7 @@ export function PreviewPanel() {
 
     tracks.forEach((track) => {
       track.elements.forEach((element) => {
+        if (element.hidden) return;
         const elementStart = element.startTime;
         const elementEnd =
           element.startTime +

--- a/apps/web/src/components/editor/timeline/timeline-element.tsx
+++ b/apps/web/src/components/editor/timeline/timeline-element.tsx
@@ -13,6 +13,10 @@ import {
   Type,
   Copy,
   RefreshCw,
+  EyeOff,
+  Eye,
+  Volume2,
+  VolumeX,
 } from "lucide-react";
 import { useMediaStore } from "@/stores/media-store";
 import { useTimelineStore } from "@/stores/timeline-store";
@@ -66,10 +70,17 @@ export function TimelineElement({
     addElementToTrack,
     replaceElementMedia,
     rippleEditingEnabled,
+    toggleElementHidden,
   } = useTimelineStore();
   const { currentTime } = usePlaybackStore();
 
   const [elementMenuOpen, setElementMenuOpen] = useState(false);
+
+  const mediaItem =
+    element.type === "media"
+      ? mediaItems.find((item) => item.id === element.mediaId)
+      : null;
+  const isAudio = mediaItem?.type === "audio";
 
   const {
     resizing,
@@ -139,6 +150,11 @@ export function TimelineElement({
     } else {
       removeElementFromTrack(track.id, element.id);
     }
+  };
+
+  const handleToggleElementHidden = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    toggleElementHidden(track.id, element.id);
   };
 
   const handleReplaceClip = (e: React.MouseEvent) => {
@@ -332,7 +348,7 @@ export function TimelineElement({
               track.type
             )} ${isSelected ? "border-b-[0.5px] border-t-[0.5px] border-foreground" : ""} ${
               isBeingDragged ? "z-50" : "z-10"
-            }`}
+            } ${element.hidden ? "opacity-50" : ""}`}
             onClick={(e) => onElementClick && onElementClick(e, element)}
             onMouseDown={handleElementMouseDown}
             onContextMenu={(e) =>
@@ -342,6 +358,16 @@ export function TimelineElement({
             <div className="absolute inset-0 flex items-center h-full">
               {renderElementContent()}
             </div>
+
+            {element.hidden && (
+              <div className="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center pointer-events-none">
+                {isAudio ? (
+                  <VolumeX className="h-6 w-6 text-white" />
+                ) : (
+                  <EyeOff className="h-6 w-6 text-white" />
+                )}
+              </div>
+            )}
 
             {isSelected && (
               <>
@@ -362,6 +388,29 @@ export function TimelineElement({
         <ContextMenuItem onClick={handleElementSplitContext}>
           <Scissors className="h-4 w-4 mr-2" />
           Split at playhead
+        </ContextMenuItem>
+        <ContextMenuItem onClick={handleToggleElementHidden}>
+          {isAudio ? (
+            element.hidden ? (
+              <Volume2 className="h-4 w-4 mr-2" />
+            ) : (
+              <VolumeX className="h-4 w-4 mr-2" />
+            )
+          ) : element.hidden ? (
+            <Eye className="h-4 w-4 mr-2" />
+          ) : (
+            <EyeOff className="h-4 w-4 mr-2" />
+          )}
+          <span>
+            {isAudio
+              ? element.hidden
+                ? "Unmute"
+                : "Mute"
+              : element.hidden
+              ? "Show"
+              : "Hide"}{" "}
+            {element.type === "text" ? "text" : "clip"}
+          </span>
         </ContextMenuItem>
         <ContextMenuItem onClick={handleElementDuplicateContext}>
           <Copy className="h-4 w-4 mr-2" />

--- a/apps/web/src/stores/timeline-store.ts
+++ b/apps/web/src/stores/timeline-store.ts
@@ -126,6 +126,7 @@ interface TimelineStore {
     pushHistory?: boolean
   ) => void;
   toggleTrackMute: (trackId: string) => void;
+  toggleElementHidden: (trackId: string, elementId: string) => void;
 
   // Split operations for elements
   splitElement: (
@@ -864,6 +865,24 @@ export const useTimelineStore = create<TimelineStore>((set, get) => {
       updateTracksAndSave(
         get()._tracks.map((track) =>
           track.id === trackId ? { ...track, muted: !track.muted } : track
+        )
+      );
+    },
+
+    toggleElementHidden: (trackId, elementId) => {
+      get().pushHistory();
+      updateTracksAndSave(
+        get()._tracks.map((track) =>
+          track.id === trackId
+            ? {
+                ...track,
+                elements: track.elements.map((element) =>
+                  element.id === elementId
+                    ? { ...element, hidden: !element.hidden }
+                    : element
+                ),
+              }
+            : track
         )
       );
     },

--- a/apps/web/src/types/timeline.ts
+++ b/apps/web/src/types/timeline.ts
@@ -11,6 +11,7 @@ interface BaseTimelineElement {
   startTime: number;
   trimStart: number;
   trimEnd: number;
+  hidden?: boolean;
 }
 
 // Media element that references MediaStore


### PR DESCRIPTION
add hide or show for media elements, mute or unmute for audio elements with a nice UI and robust corresponding functionality.

## Description

add hide or show for media elements, mute or unmute for audio elements both are effective on timeline and preview panel, with a visual overlay icon for indicating so and stored state of hidden or muted elements when reloading, exiting or any change happen


## Type of change

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Elaborately tested locally via different browsers and conditions, with reloading, states are saved and effective

**Test Configuration**:
* Node version: v24.3.0
* Browser (if applicable): Chrome, Zen, Brave
* Operating System: Windows 11 Pro

## Screenshots (if applicable)
- before: 
<img width="1919" height="1056" alt="image" src="https://github.com/user-attachments/assets/20949f7a-c1a9-4e31-9123-c007cdac786f" />

- after
a photo of a text over a hidden image showing in the panel only the visible elements as the text element in this situation and not the hidden media behind, also showing another context menu item option "Hide text" toggles with "Show text" 
<img width="1919" height="1057" alt="image" src="https://github.com/user-attachments/assets/42fd31bf-6b68-4ddd-879b-5c8c8b81da9e" />

also accounts for other media types
<img width="649" height="354" alt="image" src="https://github.com/user-attachments/assets/762b9257-2ad4-41dc-9631-d422f1caccf7" />

and audio files get "mute" or "unmute" with proper icons
<img width="730" height="354" alt="image" src="https://github.com/user-attachments/assets/d77b49c8-9930-43c1-a4b5-67e66b1fdc05" />





## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added screenshots if ui has been changed
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

