### PR TITLE
Feat/timeline return to start

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test": "vitest",
+    "test:run": "vitest run",
     "lint": "biome check src/",
     "lint:fix": "biome check src/ --write",
     "format": "biome format src/ --write",
@@ -71,6 +73,9 @@
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",
+    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/react": "^15.0.7",
+    "@testing-library/user-event": "^14.5.2",
     "@types/bun": "latest",
     "@types/node": "^24.1.0",
     "@types/pg": "^8.15.4",
@@ -78,9 +83,11 @@
     "@types/react-dom": "^18.2.18",
     "cross-env": "^7.0.3",
     "drizzle-kit": "^0.31.4",
+    "jsdom": "^26.0.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "tsx": "^4.7.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^2.1.8"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -72,6 +72,7 @@
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",
     "@types/bun": "latest",
+    "@types/node": "^24.1.0",
     "@types/pg": "^8.15.4",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",

--- a/apps/web/src/components/editor/timeline/__tests__/TimelineToolbar.test.tsx
+++ b/apps/web/src/components/editor/timeline/__tests__/TimelineToolbar.test.tsx
@@ -1,0 +1,217 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Timeline } from '../index'
+
+// Mock the stores and hooks
+vi.mock('@/stores/timeline-store', () => ({
+  useTimelineStore: () => ({
+    tracks: [],
+    addTrack: vi.fn(),
+    addElementToTrack: vi.fn(),
+    removeElementFromTrack: vi.fn(),
+    removeElementFromTrackWithRipple: vi.fn(),
+    selectedElements: [],
+    clearSelectedElements: vi.fn(),
+    splitElement: vi.fn(),
+    splitAndKeepLeft: vi.fn(),
+    splitAndKeepRight: vi.fn(),
+    separateAudio: vi.fn(),
+    snappingEnabled: false,
+    toggleSnapping: vi.fn(),
+    deleteElements: vi.fn(),
+    duplicateElement: vi.fn(),
+    selectAll: vi.fn(),
+    zoomLevel: 1,
+    setZoomLevel: vi.fn(),
+    dragState: { isDragging: false, draggedElement: null, dragOffset: { x: 0, y: 0 } },
+    getTotalDuration: () => 100,
+    setSelectedElements: vi.fn(),
+    toggleTrackMute: vi.fn(),
+  })
+}))
+
+vi.mock('@/stores/media-store', () => ({
+  useMediaStore: () => ({
+    mediaItems: [],
+    addMediaItem: vi.fn(),
+  })
+}))
+
+vi.mock('@/stores/project-store', () => ({
+  useProjectStore: () => ({
+    activeProject: null,
+  })
+}))
+
+const mockSeek = vi.fn()
+
+vi.mock('@/stores/playback-store', () => ({
+  usePlaybackStore: () => ({
+    currentTime: 0,
+    duration: 100,
+    seek: mockSeek,
+    setDuration: vi.fn(),
+    isPlaying: false,
+    toggle: vi.fn(),
+  }),
+}))
+
+// Mock the timeline playhead hook
+vi.mock('@/hooks/use-timeline-playhead', () => ({
+  useTimelinePlayhead: () => ({
+    playheadRef: { current: null },
+    updatePlayheadPosition: vi.fn(),
+    onPlayheadDrag: vi.fn(),
+  })
+}))
+
+vi.mock('@/hooks/use-editor-actions', () => ({
+  useEditorActions: () => ({})
+}))
+
+vi.mock('@/hooks/use-timeline-context-menu', () => ({
+  useTimelineContextMenu: () => ({
+    contextMenu: null,
+    handleContextMenu: vi.fn(),
+    closeContextMenu: vi.fn(),
+  })
+}))
+
+vi.mock('@/hooks/use-timeline-selection', () => ({
+  useTimelineSelection: () => ({
+    isSelecting: false,
+    selectionBox: null,
+    handleMouseDown: vi.fn(),
+  })
+}))
+
+vi.mock('@/hooks/use-timeline-drag-drop', () => ({
+  useTimelineDragDrop: () => ({
+    dragProps: {},
+  })
+}))
+
+// Mock UI components to avoid dependency issues
+vi.mock('../../ui/tooltip', () => ({
+  Tooltip: ({ children }: any) => children,
+  TooltipTrigger: ({ children }: any) => children,
+  TooltipContent: ({ children }: any) => <div>{children}</div>,
+  TooltipProvider: ({ children }: any) => children,
+}))
+
+vi.mock('../../ui/button', () => ({
+  Button: ({ children, onClick, ...props }: any) => (
+    <button onClick={onClick} {...props} aria-label={props['aria-label']}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock('../../ui/scroll-area', () => ({
+  ScrollArea: ({ children }: any) => <div>{children}</div>,
+}))
+
+vi.mock('lucide-react', () => ({
+  SkipBack: () => <svg data-testid="skip-back-icon" />,
+  Play: () => <svg data-testid="play-icon" />,
+  Pause: () => <svg data-testid="pause-icon" />,
+  Scissors: () => <svg />,
+  ArrowLeftToLine: () => <svg />,
+  ArrowRightToLine: () => <svg />,
+  Trash2: () => <svg />,
+  Snowflake: () => <svg />,
+  Copy: () => <svg />,
+  SplitSquareHorizontal: () => <svg />,
+  Video: () => <svg />,
+  Music: () => <svg />,
+  TypeIcon: () => <svg />,
+  Magnet: () => <svg />,
+  Link: () => <svg />,
+  ZoomIn: () => <svg />,
+  ZoomOut: () => <svg />,
+}))
+
+vi.mock('@/constants/timeline', () => ({
+  TIMELINE_CONSTANTS: {
+    DEFAULT_TEXT_DURATION: 5,
+  }
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: any[]) => args.join(' '),
+  snapTimeToFrame: (time: number) => time,
+}))
+
+// Mock timeline utilities
+vi.mock('@/lib/timeline-utils', () => ({
+  getTotalDuration: () => 100,
+  getCurrentSnapPoint: () => null,
+}))
+
+// Mock context menu components
+vi.mock('../../ui/context-menu', () => ({
+  ContextMenu: ({ children }: any) => children,
+  ContextMenuTrigger: ({ children }: any) => children,
+  ContextMenuContent: ({ children }: any) => <div>{children}</div>,
+  ContextMenuItem: ({ children }: any) => <div>{children}</div>,
+  ContextMenuSeparator: () => <div />,
+}))
+
+// Mock dialog components
+vi.mock('../../ui/dialog', () => ({
+  Dialog: ({ children }: any) => children,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <div>{children}</div>,
+}))
+
+describe('Timeline - Return to Start Button', () => {
+  beforeEach(() => {
+    mockSeek.mockClear()
+  })
+
+  it('should render Return to Start button', () => {
+    render(<Timeline />)
+    
+    // Look for the SkipBack icon which indicates our button
+    const skipBackIcon = screen.getByTestId('skip-back-icon')
+    expect(skipBackIcon).toBeInTheDocument()
+  })
+
+  it('should call seek(0) when Return to Start button is clicked', () => {
+    render(<Timeline />)
+    
+    // Find the button that contains the SkipBack icon
+    const skipBackIcon = screen.getByTestId('skip-back-icon')
+    const button = skipBackIcon.closest('button')
+    
+    expect(button).toBeInTheDocument()
+    fireEvent.click(button!)
+    
+    expect(mockSeek).toHaveBeenCalledWith(0)
+  })
+
+  it('should have tooltip structure for Return to Start button', () => {
+    render(<Timeline />)
+    
+    // Find the skip back button and verify it's wrapped in tooltip components
+    const skipBackIcon = screen.getByTestId('skip-back-icon')
+    const button = skipBackIcon.closest('button')
+    
+    expect(button).toBeInTheDocument()
+    // The button should exist and be clickable, which means the tooltip structure is in place
+    expect(button).toHaveAttribute('data-state', 'closed') // Tooltip trigger state
+  })
+
+  it('should have SkipBack icon in Return to Start button', () => {
+    render(<Timeline />)
+    
+    const skipBackIcon = screen.getByTestId('skip-back-icon')
+    expect(skipBackIcon).toBeInTheDocument()
+    
+    // Verify it's inside a button
+    const button = skipBackIcon.closest('button')
+    expect(button).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/editor/timeline/index.tsx
+++ b/apps/web/src/components/editor/timeline/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import { ScrollArea } from "../../ui/scroll-area";
 import { Button } from "../../ui/button";
 import {
@@ -984,12 +985,13 @@ function TimelineToolbar({
               {isPlaying ? "Pause (Space)" : "Play (Space)"}
             </TooltipContent>
           </Tooltip>
+          {/* Return to Start Button - Seeks timeline to 00:00:00 */}
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
                 variant="text"
                 size="icon"
-                onClick={() => seek(0)}
+                onClick={() => seek(0)} // Seek to timeline start position
                 className="mr-2"
               >
                 <SkipBack className="h-4 w-4" />

--- a/apps/web/src/components/editor/timeline/index.tsx
+++ b/apps/web/src/components/editor/timeline/index.tsx
@@ -12,6 +12,7 @@ import {
   SplitSquareHorizontal,
   Pause,
   Play,
+  SkipBack,
   Video,
   Music,
   TypeIcon,
@@ -508,7 +509,7 @@ export function Timeline() {
       onMouseEnter={() => setIsInTimeline(true)}
       onMouseLeave={() => setIsInTimeline(false)}
     >
-      <TimelineToolbar zoomLevel={zoomLevel} setZoomLevel={setZoomLevel} />
+      <TimelineToolbar zoomLevel={zoomLevel} setZoomLevel={setZoomLevel} seek={seek} />
 
       {/* Timeline Container */}
       <div
@@ -806,9 +807,11 @@ function TrackIcon({ track }: { track: TimelineTrack }) {
 function TimelineToolbar({
   zoomLevel,
   setZoomLevel,
+  seek,
 }: {
   zoomLevel: number;
   setZoomLevel: (zoom: number) => void;
+  seek: (time: number) => void;
 }) {
   const {
     tracks,
@@ -979,6 +982,21 @@ function TimelineToolbar({
             </TooltipTrigger>
             <TooltipContent>
               {isPlaying ? "Pause (Space)" : "Play (Space)"}
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="text"
+                size="icon"
+                onClick={() => seek(0)}
+                className="mr-2"
+              >
+                <SkipBack className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Return to Start (Home / Enter)
             </TooltipContent>
           </Tooltip>
           <div className="w-px h-6 bg-border mx-1" />

--- a/apps/web/src/components/editor/timeline/timeline-playhead.tsx
+++ b/apps/web/src/components/editor/timeline/timeline-playhead.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useEffect } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import { TimelineTrack } from "@/types/timeline";
 import { TIMELINE_CONSTANTS } from "@/constants/timeline-constants";
 import { useTimelinePlayhead } from "@/hooks/use-timeline-playhead";

--- a/apps/web/src/hooks/__tests__/use-keyboard-shortcuts-help.test.ts
+++ b/apps/web/src/hooks/__tests__/use-keyboard-shortcuts-help.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useKeyboardShortcutsHelp } from '../use-keyboard-shortcuts-help'
+import { useKeybindingsStore } from '../../stores/keybindings-store'
+
+describe('useKeyboardShortcutsHelp', () => {
+  beforeEach(() => {
+    // Reset store to default state before each test
+    useKeybindingsStore.getState().resetToDefaults()
+  })
+
+  it('should format Enter key correctly in shortcuts', () => {
+    const { result } = renderHook(() => useKeyboardShortcutsHelp())
+    
+    // Find the goto-start action in shortcuts
+    const gotoStartShortcut = result.current.shortcuts.find(
+      shortcut => shortcut.action === 'goto-start'
+    )
+    
+    expect(gotoStartShortcut).toBeDefined()
+    expect(gotoStartShortcut?.keys).toContain('Enter')
+    expect(gotoStartShortcut?.keys).toContain('Home')
+  })
+
+  it('should include goto-start action with correct description', () => {
+    const { result } = renderHook(() => useKeyboardShortcutsHelp())
+    
+    const gotoStartShortcut = result.current.shortcuts.find(
+      shortcut => shortcut.action === 'goto-start'
+    )
+    
+    expect(gotoStartShortcut).toBeDefined()
+    expect(gotoStartShortcut?.description).toBe('Go to timeline start')
+    expect(gotoStartShortcut?.category).toBe('Navigation')
+  })
+
+  it('should have multiple keys for goto-start action', () => {
+    const { result } = renderHook(() => useKeyboardShortcutsHelp())
+    
+    const gotoStartShortcut = result.current.shortcuts.find(
+      shortcut => shortcut.action === 'goto-start'
+    )
+    
+    expect(gotoStartShortcut?.keys.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/apps/web/src/hooks/use-keyboard-shortcuts-help.ts
+++ b/apps/web/src/hooks/use-keyboard-shortcuts-help.ts
@@ -77,7 +77,7 @@ const formatKey = (key: string): string => {
     .replace("down", "↓")
     .replace("space", "Space")
     .replace("home", "Home")
-    .replace("enter", "Enter")
+    .replace("enter", "Enter") // Format Enter key for display in help dialog
     .replace("end", "End")
     .replace("delete", "Delete")
     .replace("backspace", "Backspace")

--- a/apps/web/src/hooks/use-keyboard-shortcuts-help.ts
+++ b/apps/web/src/hooks/use-keyboard-shortcuts-help.ts
@@ -77,6 +77,7 @@ const formatKey = (key: string): string => {
     .replace("down", "↓")
     .replace("space", "Space")
     .replace("home", "Home")
+    .replace("enter", "Enter")
     .replace("end", "End")
     .replace("delete", "Delete")
     .replace("backspace", "Backspace")

--- a/apps/web/src/stores/__tests__/keybindings-store.test.ts
+++ b/apps/web/src/stores/__tests__/keybindings-store.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useKeybindingsStore } from '../keybindings-store'
+
+describe('Keybindings Store', () => {
+  beforeEach(() => {
+    // Reset store to default state before each test
+    useKeybindingsStore.getState().resetToDefaults()
+  })
+
+  describe('Default Keybindings', () => {
+    it('should include Enter key mapping to goto-start action', () => {
+      const { keybindings } = useKeybindingsStore.getState()
+      expect(keybindings.enter).toBe('goto-start')
+    })
+
+    it('should include Home key mapping to goto-start action', () => {
+      const { keybindings } = useKeybindingsStore.getState()
+      expect(keybindings.home).toBe('goto-start')
+    })
+
+    it('should have both Enter and Home keys for the same action', () => {
+      const { keybindings } = useKeybindingsStore.getState()
+      expect(keybindings.enter).toBe(keybindings.home)
+    })
+  })
+
+  describe('getKeybindingsForAction', () => {
+    it('should return both Enter and Home keys for goto-start action', () => {
+      const { getKeybindingsForAction } = useKeybindingsStore.getState()
+      const keys = getKeybindingsForAction('goto-start')
+      
+      expect(keys).toContain('enter')
+      expect(keys).toContain('home')
+      expect(keys.length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  describe('Keyboard Event Parsing', () => {
+    it('should generate correct keybinding string for Enter key', () => {
+      const { getKeybindingString } = useKeybindingsStore.getState()
+      
+      // Mock KeyboardEvent for Enter key
+      const enterEvent = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        code: 'Enter'
+      })
+      
+      const result = getKeybindingString(enterEvent)
+      expect(result).toBe('enter')
+    })
+
+    it('should generate correct keybinding string for Home key', () => {
+      const { getKeybindingString } = useKeybindingsStore.getState()
+      
+      // Mock KeyboardEvent for Home key
+      const homeEvent = new KeyboardEvent('keydown', {
+        key: 'Home',
+        code: 'Home'
+      })
+      
+      const result = getKeybindingString(homeEvent)
+      expect(result).toBe('home')
+    })
+  })
+})

--- a/apps/web/src/stores/keybindings-store.ts
+++ b/apps/web/src/stores/keybindings-store.ts
@@ -17,7 +17,7 @@ export const defaultKeybindings: KeybindingConfig = {
   "shift+left": "jump-backward",
   "shift+right": "jump-forward",
   home: "goto-start",
-  enter: "goto-start",
+  enter: "goto-start", // More intuitive alternative to Home key for timeline navigation
   end: "goto-end",
   s: "split-element",
   n: "toggle-snapping",

--- a/apps/web/src/stores/keybindings-store.ts
+++ b/apps/web/src/stores/keybindings-store.ts
@@ -17,6 +17,7 @@ export const defaultKeybindings: KeybindingConfig = {
   "shift+left": "jump-backward",
   "shift+right": "jump-forward",
   home: "goto-start",
+  enter: "goto-start",
   end: "goto-end",
   s: "split-element",
   n: "toggle-snapping",

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,0 +1,8 @@
+import '@testing-library/jest-dom'
+
+// Mock ResizeObserver
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+})

--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.16",
         "@types/bun": "latest",
+        "@types/node": "^24.1.0",
         "@types/pg": "^8.15.4",
         "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.18",
@@ -1314,6 +1315,8 @@
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
+    "opencut/@types/node": ["@types/node@24.1.0", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w=="],
+
     "opencut/next": ["next@15.4.5", "", { "dependencies": { "@next/env": "15.4.5", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.5", "@next/swc-darwin-x64": "15.4.5", "@next/swc-linux-arm64-gnu": "15.4.5", "@next/swc-linux-arm64-musl": "15.4.5", "@next/swc-linux-x64-gnu": "15.4.5", "@next/swc-linux-x64-musl": "15.4.5", "@next/swc-win32-arm64-msvc": "15.4.5", "@next/swc-win32-x64-msvc": "15.4.5", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-nJ4v+IO9CPmbmcvsPebIoX3Q+S7f6Fu08/dEWu0Ttfa+wVwQRh9epcmsyCPjmL2b8MxC+CkBR97jgDhUUztI3g=="],
 
     "opencut/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -1391,6 +1394,8 @@
     "motion/framer-motion/motion-dom": ["motion-dom@12.23.6", "", { "dependencies": { "motion-utils": "^12.23.6" } }, "sha512-G2w6Nw7ZOVSzcQmsdLc0doMe64O/Sbuc2bVAbgMz6oP/6/pRStKRiVRV4bQfHp5AHYAKEGhEdVHTM+R3FDgi5w=="],
 
     "motion/framer-motion/motion-utils": ["motion-utils@12.23.6", "", {}, "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ=="],
+
+    "opencut/@types/node/undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
 
     "opencut/next/@next/env": ["@next/env@15.4.5", "", {}, "sha512-ruM+q2SCOVCepUiERoxOmZY9ZVoecR3gcXNwCYZRvQQWRjhOiPJGmQ2fAiLR6YKWXcSAh7G79KEFxN3rwhs4LQ=="],
 


### PR DESCRIPTION
- Add Enter key shortcut for seeking to timeline start (00:00:00)
- Add return to start button in timeline toolbar with skip-back icon
- Both methods complement existing Home key shortcut
- Update keyboard shortcuts help to display Enter key properly
- Maintain consistent UI styling with existing playback controls

Resolves #415

## Description

Users often need to return to the start of the timeline (00:00:00) when working on projects, but this can be frustrating when they're zoomed in on specific areas or scrolled far down the timeline. Currently, only the Home key provides this functionality, which isn't intuitive for all users.

Fixes # (415)

## Type of change

- ☑️  New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Test Enter key when timeline is focused → seeks to 00:00:00
- Test Return to Start button click → seeks to 00:00:00
- Test existing Home key functionality → still works as before
- Test keyboard shortcuts help dialog → shows both Enter and Home keys
- Test that Enter key doesn't interfere with input fields → only works when timeline focused 

**Test Configuration**:
  - Package Manager: Bun 1.2.18
  - Browser: Arc
  - Operating System: macOS

## Screenshots


https://github.com/user-attachments/assets/2ae85ce3-d36f-4c28-acbb-0fb7852e2cac



## Checklist:

☑️ My code follows the style guidelines of this project
☑️ I have performed a self-review of my code
☑️ I have added screenshots if ui has been changed
☑️ I have commented my code, particularly in hard-to-understand areas
☑️ I have made corresponding changes to the documentation
☑️ My changes generate no new warnings
☑️ I have added tests that prove my fix is effective or that my feature works
☑️ New and existing unit tests pass locally with my changes
☑️ Any dependent changes have been merged and published in downstream modules
