### PR TITLE
fix: adjust playhead z-index to 50 for better layering

### DIFF
--- a/apps/web/src/components/editor/timeline/timeline-playhead.tsx
+++ b/apps/web/src/components/editor/timeline/timeline-playhead.tsx
@@ -126,7 +126,7 @@ export function TimelinePlayhead({
   return (
     <div
       ref={playheadRef}
-      className="absolute pointer-events-auto z-150"
+      className="absolute pointer-events-auto z-50"
       style={{
         left: `${leftPosition}px`,
         top: 0,


### PR DESCRIPTION
## Description
Adjusted the z-index of the timeline playhead from `z-150` to `z-50` to resolve layering issues with other UI elements.
#507 (solved)

## Changes Made
- Modified the playhead's z-index in [timeline-playhead.tsx](cci:7://file:///d:/OpenCutt/apps/web/src/components/editor/timeline/timeline-playhead.tsx:0:0-0:0) to ensure proper layering with other timeline components
- The new z-index of 50 maintains visibility while preventing it from appearing above other important UI elements

## Why This Change Was Needed
- The playhead's previous z-index of 150 was causing it to appear above elements that should have been in the foreground
- This adjustment ensures better visual hierarchy and prevents the playhead from overlapping with other interface elements

## Testing
- Verified that the playhead remains visible during playback
- Confirmed that the playhead no longer appears above other UI elements
- Tested timeline interactions to ensure all functionality remains intact

##Before

https://github.com/user-attachments/assets/1dad0173-1048-45ac-b5e6-774f2c81c599

##After

https://github.com/user-attachments/assets/7bf63b71-e00f-4449-b383-a4c18a4f6872



## Related Issues
Fixes #[issue-number]

## Checklist
- [x] My code follows the project's coding style
- [x] I have tested these changes
- [x] My changes don't break existing functionality