### PR TITLE
fix: enable removing background color in text back to transparent and remember last selection

### DIFF
--- a/apps/web/src/components/editor/properties-panel/text-properties.tsx
+++ b/apps/web/src/components/editor/properties-panel/text-properties.tsx
@@ -7,7 +7,7 @@ import { Slider } from "@/components/ui/slider";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch"; // Add Switch import
-import { useState } from "react";
+import { useState, useRef } from "react";
 import {
   PropertyItem,
   PropertyItemLabel,
@@ -30,6 +30,9 @@ export function TextProperties({
   const [opacityInput, setOpacityInput] = useState(
     Math.round(element.opacity * 100).toString()
   );
+
+  // Track the last selected color for toggling
+  const lastSelectedColor = useRef("#000000");
 
   const parseAndValidateNumber = (
     value: string,
@@ -85,6 +88,20 @@ export function TextProperties({
     );
     setOpacityInput(opacityPercent.toString());
     updateTextElement(trackId, element.id, { opacity: opacityPercent / 100 });
+  };
+
+  // Update last selected color when a new color is picked
+  const handleColorChange = (color: string) => {
+    if (color !== "transparent") {
+      lastSelectedColor.current = color;
+    }
+    updateTextElement(trackId, element.id, { backgroundColor: color });
+  };
+
+  // Toggle between transparent and last selected color
+  const handleTransparentToggle = (isTransparent: boolean) => {
+    const newColor = isTransparent ? "transparent" : lastSelectedColor.current;
+    updateTextElement(trackId, element.id, { backgroundColor: newColor });
   };
 
   return (
@@ -228,14 +245,7 @@ export function TextProperties({
             <Switch
               id="transparent-bg-toggle"
               checked={element.backgroundColor === "transparent"}
-              onCheckedChange={(isChecked) => {
-                // When turning transparency on, set to "transparent"
-                // When turning off, default to black or a stored previous color
-                const newColor = isChecked ? "transparent" : "#000000";
-                updateTextElement(trackId, element.id, {
-                  backgroundColor: newColor,
-                });
-              }}
+              onCheckedChange={handleTransparentToggle}
             />
             <label htmlFor="transparent-bg-toggle" className="text-sm font-medium">
               Transparent
@@ -247,13 +257,10 @@ export function TextProperties({
             type="color"
             value={
               element.backgroundColor === "transparent"
-                ? "#000000" // Display black in picker when transparent is active
+                ? lastSelectedColor.current
                 : element.backgroundColor || "#000000"
             }
-            onChange={(e) => {
-              const backgroundColor = e.target.value;
-              updateTextElement(trackId, element.id, { backgroundColor });
-            }}
+            onChange={(e) => handleColorChange(e.target.value)}
             className="w-full cursor-pointer rounded-full"
             disabled={element.backgroundColor === "transparent"}
           />

--- a/apps/web/src/components/editor/properties-panel/text-properties.tsx
+++ b/apps/web/src/components/editor/properties-panel/text-properties.tsx
@@ -6,6 +6,7 @@ import { useTimelineStore } from "@/stores/timeline-store";
 import { Slider } from "@/components/ui/slider";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch"; // Add Switch import
 import { useState } from "react";
 import {
   PropertyItem,
@@ -220,14 +221,33 @@ export function TextProperties({
           />
         </PropertyItemValue>
       </PropertyItem>
-      <PropertyItem direction="row">
-        <PropertyItemLabel>Background</PropertyItemLabel>
+      <PropertyItem direction="column">
+        <div className="flex items-center justify-between">
+          <PropertyItemLabel>Background</PropertyItemLabel>
+          <div className="flex items-center space-x-2">
+            <Switch
+              id="transparent-bg-toggle"
+              checked={element.backgroundColor === "transparent"}
+              onCheckedChange={(isChecked) => {
+                // When turning transparency on, set to "transparent"
+                // When turning off, default to black or a stored previous color
+                const newColor = isChecked ? "transparent" : "#000000";
+                updateTextElement(trackId, element.id, {
+                  backgroundColor: newColor,
+                });
+              }}
+            />
+            <label htmlFor="transparent-bg-toggle" className="text-sm font-medium">
+              Transparent
+            </label>
+          </div>
+        </div>
         <PropertyItemValue>
           <Input
             type="color"
             value={
               element.backgroundColor === "transparent"
-                ? "#000000"
+                ? "#000000" // Display black in picker when transparent is active
                 : element.backgroundColor || "#000000"
             }
             onChange={(e) => {
@@ -235,6 +255,7 @@ export function TextProperties({
               updateTextElement(trackId, element.id, { backgroundColor });
             }}
             className="w-full cursor-pointer rounded-full"
+            disabled={element.backgroundColor === "transparent"}
           />
         </PropertyItemValue>
       </PropertyItem>


### PR DESCRIPTION
## Improved Background Color Management
#509 
### What's New
- Fixed issue where background color couldn't be removed after being set
- Added proper toggle between colored and transparent backgrounds
- Now remembers your last selected color when toggling

### Before
- Once you set a background color, it was permanent
- No way to go back to transparent
- Frustrating user experience

https://github.com/user-attachments/assets/9293e86a-7049-4e97-b6f8-d77508c82509



### Now
- Toggle background on/off easily
- Your color choices are remembered
- Smooth transitions between states

https://github.com/user-attachments/assets/97a1b1fb-97f1-4d10-81cd-b503f4aa1780


### How It Works
1. Set any background color
2. Toggle to transparent when needed
3. Toggle back to see your last color
4. Change colors anytime - it remembers!