### PR TITLE
restore horizontal scroll sync after Radix ScrollArea removal

### DIFF
--- a/apps/web/src/components/editor/timeline/index.tsx
+++ b/apps/web/src/components/editor/timeline/index.tsx
@@ -426,15 +426,9 @@ export function Timeline() {
 
   // --- Scroll synchronization effect ---
   useEffect(() => {
-    const rulerViewport = rulerScrollRef.current?.querySelector(
-      "[data-radix-scroll-area-viewport]"
-    ) as HTMLElement;
-    const tracksViewport = tracksScrollRef.current?.querySelector(
-      "[data-radix-scroll-area-viewport]"
-    ) as HTMLElement;
-    const trackLabelsViewport = trackLabelsScrollRef.current?.querySelector(
-      "[data-radix-scroll-area-viewport]"
-    ) as HTMLElement;
+    const rulerViewport = rulerScrollRef.current;
+    const tracksViewport = tracksScrollRef.current;
+    const trackLabelsViewport = trackLabelsScrollRef.current;
 
     if (!rulerViewport || !tracksViewport) return;
 


### PR DESCRIPTION
## Description

Restores horizontal scroll synchronization between the timeline ruler and the track section, which was broken after the removal of the Radix `ScrollArea`.

This regression was introduced in commit `c0651fe`. The previous implementation relied on Radix-specific DOM selectors which no longer exist.

Fixes #517 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manually tested scroll behavior in the editor after launching with `bun dev`
- Verified that scrolling in the track section correctly syncs the ruler (timeline header)

**Test Configuration**:
* Node version: v20+
* Browser: Chrome 138.0.7204.93
* OS: Windows 11

## Screenshots (if applicable)

Before:

https://github.com/user-attachments/assets/2b8dac91-9191-4689-a1df-2d69c9f3c060

After:

https://github.com/user-attachments/assets/88c51e63-2542-4b77-8fc9-f0b0fe162c0d


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A for this small fix)
- [ ] New and existing unit tests pass locally with my changes (N/A)
- [ ] Any dependent changes have been merged and published in downstream modules



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified scroll synchronization in the Timeline component for improved maintainability. No visible changes to user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->