### PR TITLE
fix prevent timeline playhead freeze | dynamic buffer

### DIFF
--- a/apps/web/src/components/editor/timeline/index.tsx
+++ b/apps/web/src/components/editor/timeline/index.tsx
@@ -108,7 +108,7 @@ export function Timeline() {
   // Dynamic timeline width calculation based on playhead position and duration
   const dynamicTimelineWidth = Math.max(
     (duration || 0) * TIMELINE_CONSTANTS.PIXELS_PER_SECOND * zoomLevel, // Base width from duration
-    (currentTime + 30) * TIMELINE_CONSTANTS.PIXELS_PER_SECOND * zoomLevel, // Width to show current time + 30 seconds buffer
+    (currentTime + Math.max(60, duration * 0.1)) * TIMELINE_CONSTANTS.PIXELS_PER_SECOND * zoomLevel, // Dynamic buffer: 60s minimum or 10% of duration
     timelineRef.current?.clientWidth || 1000 // Minimum width
   );
 

--- a/apps/web/src/components/editor/timeline/timeline-playhead.tsx
+++ b/apps/web/src/components/editor/timeline/timeline-playhead.tsx
@@ -51,9 +51,10 @@ export function TimelinePlayhead({
 
   // Track scroll position to lock playhead to frame
   useEffect(() => {
-    const tracksViewport = tracksScrollRef.current?.querySelector(
-      "[data-radix-scroll-area-viewport]"
-    ) as HTMLElement;
+    const tracksViewport =
+      (tracksScrollRef.current?.querySelector(
+        "[data-radix-scroll-area-viewport]"
+      ) as HTMLElement | null) || tracksScrollRef.current;
 
     if (!tracksViewport) return;
 
@@ -86,9 +87,10 @@ export function TimelinePlayhead({
   // Get the timeline content width and viewport width for right boundary
   const timelineContentWidth =
     duration * TIMELINE_CONSTANTS.PIXELS_PER_SECOND * zoomLevel;
-  const tracksViewport = tracksScrollRef.current?.querySelector(
-    "[data-radix-scroll-area-viewport]"
-  ) as HTMLElement;
+  const tracksViewport =
+    (tracksScrollRef.current?.querySelector(
+      "[data-radix-scroll-area-viewport]"
+    ) as HTMLElement | null) || tracksScrollRef.current;
   const viewportWidth = tracksViewport?.clientWidth || 1000;
 
   // Constrain playhead to never appear outside the timeline area


### PR DESCRIPTION
## Description

Fixes the timeline playhead freezing issue that occurs after 20 seconds of video playback. The playhead would stop moving visually even though the video continued playing, making it impossible to track the current playback position.

**Root Cause**: 
- Timeline width buffer was insufficient (30 seconds) for longer videos
- Playhead positioning calculations failed when currentTime exceeded the buffer

**Solution**:
- Implemented dynamic buffer for timeline width: `Math.max(60s, 10% of duration (for any duration))`

Fixes #523 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Node version: v20+
* Browser: Chrome 138.0.7204.93
* Operating System: Windows 11

## Screenshots (if applicable)

Before: Playhead stops moving at 20 seconds mark
<img width="977" height="591" alt="image" src="https://github.com/user-attachments/assets/fc480924-8d01-435d-a680-1b9edbee4135" />

After: Playhead continues moving throughout entire video duration


https://github.com/user-attachments/assets/2f09723b-4ec2-4754-8d92-40049fc26482


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A for this small fix)
- [ ] New and existing unit tests pass locally with my changes (N/A)
- [ ] Any dependent changes have been merged and published in downstream modules


**Details**:
- Dynamic buffer calculation: `Math.max(60, duration * 0.1)` seconds
- Minimum 60-second buffer for short videos
- 10% of duration buffer for longer videos (e.g., 6 minutes for 1-hour video)
- Maintains existing scroll synchronization functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced the timeline view to show a larger and more dynamic buffer beyond the current playhead, ensuring better visibility of upcoming content. The buffer now adapts based on the timeline duration, with a minimum of 60 seconds or 10% of the total length.
  * Improved timeline scrolling behavior to maintain smooth operation even if certain viewport elements are missing, preventing potential display issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->