### PR TITLE
fix(preview): mute button not affecting embedded video audio, ensure topmost video track renders above lower tracksmute button not affecting embedded video audio (#529)

### DIFF
--- a/apps/web/src/components/editor/preview-panel.tsx
+++ b/apps/web/src/components/editor/preview-panel.tsx
@@ -223,7 +223,8 @@ export function PreviewPanel() {
   const getActiveElements = (): ActiveElement[] => {
     const activeElements: ActiveElement[] = [];
 
-    tracks.forEach((track) => {
+    // Iterate tracks from bottom to top so topmost track renders last (on top)
+    ;[...tracks].reverse().forEach((track) => {
       track.elements.forEach((element) => {
         if (element.hidden) return;
         const elementStart = element.startTime;
@@ -448,7 +449,7 @@ export function PreviewPanel() {
       // Audio elements (no visual representation)
       if (mediaItem.type === "audio") {
         return (
-          <div key={element.id} className="absolute inset-0">
+          <div key={element.id} className="absolute inset-0" style={{ pointerEvents: "none" }}>
             <AudioPlayer
               src={mediaItem.url!}
               clipStartTime={element.startTime}

--- a/apps/web/src/components/editor/preview-panel.tsx
+++ b/apps/web/src/components/editor/preview-panel.tsx
@@ -301,6 +301,7 @@ export function PreviewPanel() {
             trimEnd={element.trimEnd}
             clipDuration={element.duration}
             className="w-full h-full object-cover"
+            trackMuted={true}
           />
         </div>
       );
@@ -424,6 +425,7 @@ export function PreviewPanel() {
               trimStart={element.trimStart}
               trimEnd={element.trimEnd}
               clipDuration={element.duration}
+              trackMuted={elementData.track.muted}
             />
           </div>
         );

--- a/apps/web/src/components/ui/video-player.tsx
+++ b/apps/web/src/components/ui/video-player.tsx
@@ -11,6 +11,7 @@ interface VideoPlayerProps {
   trimStart: number;
   trimEnd: number;
   clipDuration: number;
+  trackMuted?: boolean;
 }
 
 export function VideoPlayer({
@@ -21,6 +22,7 @@ export function VideoPlayer({
   trimStart,
   trimEnd,
   clipDuration,
+  trackMuted = false,
 }: VideoPlayerProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const { isPlaying, currentTime, volume, speed, muted } = usePlaybackStore();
@@ -109,9 +111,9 @@ export function VideoPlayer({
     if (!video) return;
 
     video.volume = volume;
-    video.muted = muted;
+    video.muted = muted || trackMuted;
     video.playbackRate = speed;
-  }, [volume, speed, muted]);
+  }, [volume, speed, muted, trackMuted]);
 
   return (
     <video


### PR DESCRIPTION
Summary
- Fix preview stacking so that the topmost video track always renders above lower tracks
- Make audio layer container non-interactive (pointer-events: none) so it can’t intercept clicks

Why
When multiple video tracks are present, the preview sometimes showed content from the bottom-most track despite a full clip on the top track. Root cause was render order: the preview collected and rendered active elements in the same UI order (top→bottom), so bottom tracks were appended last and ended up on top in the DOM.

What changed
- In apps/web/src/components/editor/preview-panel.tsx, iterate tracks in reverse (bottom→top) when computing active elements so lower tracks render first and the topmost track renders last, ensuring correct stacking.
- Mark audio container with pointer-events: none to avoid any chance of it obstructing interactions.

Testing
- Created 3 video tracks; split the lowest track into multiple segments; placed a full clip on the top track; scrubbed and played. The top track remains visible at all times.
- Verified that text layers still render above video (they use zIndex).
- Blur background still behaves as expected.

Notes
This change is deliberately minimal and avoids broader preview refactors, aligning with the CONTRIBUTING.md note that a larger preview overhaul is planned.

Closes #529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **Bug Fixes**
  * Improved the visual stacking order of tracks in the preview panel so that topmost tracks now appear correctly above lower tracks.
  * Updated audio media elements to prevent their containers from intercepting pointer events, allowing for better interaction with underlying elements.
  * Enhanced video playback by muting tracks appropriately based on their muted state, ensuring consistent audio behavior in the preview panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->