### PR TITLE
feat(playback): restart from beginning when play pressed at end of timeline (Fixes #536)

### DIFF
--- a/apps/web/src/stores/playback-store.ts
+++ b/apps/web/src/stores/playback-store.ts
@@ -82,6 +82,24 @@ export const usePlaybackStore = create<PlaybackStore>((set, get) => ({
   speed: 1.0,
 
   play: () => {
+    const state = get();
+
+    const actualContentDuration = useTimelineStore
+      .getState()
+      .getTotalDuration();
+    const effectiveDuration =
+      actualContentDuration > 0 ? actualContentDuration : state.duration;
+
+    if (effectiveDuration > 0) {
+      const fps = useProjectStore.getState().activeProject?.fps ?? 30;
+      const frameOffset = 1 / fps;
+      const endThreshold = Math.max(0, effectiveDuration - frameOffset);
+
+      if (state.currentTime >= endThreshold) {
+        get().seek(0);
+      }
+    }
+
     set({ isPlaying: true });
     startTimer(get);
   },


### PR DESCRIPTION
## Description

When Play (or Space) is pressed while the playhead is at the end of the timeline, playback now restarts from the beginning (time 0) and continues playing.

* Compute effectiveDuration from the actual timeline content duration (useTimelineStore.getTotalDuration()) with a fallback to the store’s duration.
* Use the project FPS (default 30) to derive a one-frame offset: frameOffset = 1 / fps.
* Define endThreshold = max(0, effectiveDuration - frameOffset).
* If currentTime >= endThreshold, call seek(0) to reset to the beginning.
* Then set isPlaying to true and start the rAF timer.

## Why here

* toggle() calls play() when resuming. Centralizing this logic in play() ensures pressing Space (or clicking the button) restarts from the beginning after reaching the end.
* seek(0) emits the existing playback-seek event, keeping media elements in sync.
* TimelinePlayhead already derives position from currentTime, so it reflects the jump to 0 automatically.

Fixes #536

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Tests

## How Has This Been Tested?
* Seek the playhead to the end of the timeline and press Space or click Play: it seeks to 0 and starts playback.
* Press Space/Play when not at the end: playback resumes from the current position.
* Empty timeline or zero duration: behavior unchanged and no errors.
* Verified with different FPS values (24/30/60) to ensure correct end detection using a one-frame threshold.
* Verified in both normal and fullscreen preview.

## Repro steps:

* bun dev
* Open the editor, add media so the timeline has non-zero duration.
* Drag the playhead to the end and press Space or click Play.
* Observe: playhead jumps to 0 and playback starts.

**Test Configuration**:
* Node version:
* Browser (if applicable):
* Operating System:

## Screenshots (if applicable)


https://github.com/user-attachments/assets/712cd243-62a7-4284-bdf8-e0c3a0332a41



## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have added screenshots if ui has been changed
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context
Centralizing the logic in the playback store’s play() ensures consistent behavior regardless of how playback is toggled