### PR TITLE
Fix broken homepage image link

### DIFF
--- a/apps/web/src/components/landing/hero.tsx
+++ b/apps/web/src/components/landing/hero.tsx
@@ -9,17 +9,23 @@ import { ArrowRight } from "lucide-react";
 import Image from "next/image";
 import { Handlebars } from "./handlebars";
 import Link from "next/link";
+import { useState } from "react";
 
 export function Hero() {
+  const [bgError, setBgError] = useState(false);
   return (
     <div className="min-h-[calc(100vh-4.5rem)] supports-[height:100dvh]:min-h-[calc(100dvh-4.5rem)] flex flex-col justify-between items-center text-center px-4">
-      <Image
-        className="absolute top-0 left-0 -z-50 size-full object-cover invert dark:invert-0 opacity-85"
-        src="/landing-page-bg.png"
-        height={1903.5}
-        width={1269}
-        alt="landing-page.bg"
-      />
+      {!bgError && (
+        <Image
+          className="absolute top-0 left-0 -z-50 size-full object-cover invert dark:invert-0 opacity-85"
+          src="/landing-page-dark.png"
+          height={1903.5}
+          width={1269}
+          alt="Landing page background"
+          onError={() => setBgError(true)}
+          priority
+        />
+      )}
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}


### PR DESCRIPTION
## Summary

Fix broken homepage background image by switching to an existing asset and adding error handling to prevent broken image icons from appearing.

## Why

The homepage Hero component referenced `/landing-page-bg.png` which doesn't exist in the public directory. This caused a broken image icon to appear in the top corner of the homepage, degrading the user experience. The issue was reported in #543 with screenshots showing the broken image placeholder.

## What changed

- **Updated image source**: Changed from non-existent `/landing-page-bg.png` to existing `/landing-page-dark.png`
- **Added error fallback**: Introduced `useState` to track image load errors and conditionally hide the image if it fails to load
- **Improved accessibility**: Updated alt text from generic "landing-page.bg" to descriptive "Landing page background"
- **Enhanced performance**: Added `priority` prop to ensure the background image loads quickly

In `apps/web/src/components/landing/hero.tsx`:
- Import `useState` from React
- Add `bgError` state to track image loading failures
- Wrap `<Image>` in conditional rendering `{!bgError && (...)}`
- Add `onError={() => setBgError(true)}` handler
- Switch `src` to `/landing-page-dark.png` (confirmed to exist in `apps/web/public/`)

## Testing

- Verified `/landing-page-dark.png` exists in the public directory
- The existing CSS classes `invert dark:invert-0` ensure the dark image works correctly across light/dark themes
- If the image fails to load for any reason, it gracefully disappears instead of showing a broken icon
- Background styling and layout remain unchanged

## Notes

This fix is minimal and focused - it addresses the immediate broken image issue without changing the overall design or layout. The solution follows the expected behavior outlined in the issue: "If the image file is missing or invalid, the image element should be removed or replaced with a placeholder."

Closes #543

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author