### PR TITLE
refactor: getVideoInfo uses ffprobe instead of ffmpeg

### DIFF
--- a/apps/web/src/lib/ffmpeg-utils.ts
+++ b/apps/web/src/lib/ffmpeg-utils.ts
@@ -138,7 +138,7 @@ export const getVideoInfo = async (
       inputName,
       "-o",
       ffprobeOutputJson,
-    ])
+    ]);
     const json = await ffmpeg.readFile(ffprobeOutputJson, "utf8");
 
     const info = JSON.parse(json as string);


### PR DESCRIPTION
getVideoInfo uses ffprobe instead of ffmpeg, because ffmpeg is very slow at 4K 60fps

## Description

The command "ffmpeg -i 4k_60fps.mp4 -f null -" runs at a speed of less than 0.5x on my computer, meaning it takes over two minutes to retrieve information from a 60-second video. 
Advantages of ffprobe:
- Consistently fast performance, largely unaffected by video file size.
- Can extract more detailed information, such as pix_fmt, color_space, etc.
- Supports output in specified formats, such as JSON.


## Type of change

Please delete options that are not relevant.

- [x] Performance improvement
- [x] Code refactoring


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have added screenshots if ui has been changed
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable detection of video duration, resolution, and FPS across a wider range of formats.
  * Reduced failures when analyzing unsupported or corrupted files; clearer error messages on analysis errors.
  * Improved cleanup after processing to prevent leftover temporary files.

* **Refactor**
  * Internal overhaul of video analysis to enhance accuracy, stability, and maintainability without changing public behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->