### PR TITLE
fix(editor): Don't log expected errors in `AudioWaveform` during unmount

### DIFF
--- a/apps/web/src/components/editor/audio-waveform.tsx
+++ b/apps/web/src/components/editor/audio-waveform.tsx
@@ -67,8 +67,8 @@ const AudioWaveform: React.FC<AudioWaveformProps> = ({
         });
 
         newWaveSurfer.on("error", (err) => {
-          console.error("WaveSurfer error:", err);
           if (mounted) {
+            console.error("WaveSurfer error:", err);
             setError(true);
             setIsLoading(false);
           }
@@ -76,8 +76,8 @@ const AudioWaveform: React.FC<AudioWaveformProps> = ({
 
         await newWaveSurfer.load(audioUrl);
       } catch (err) {
-        console.error("Failed to initialize WaveSurfer:", err);
         if (mounted) {
+          console.error("Failed to initialize WaveSurfer:", err);
           setError(true);
           setIsLoading(false);
         }


### PR DESCRIPTION
## Description

Currently, an error is logged whenever there is an audio layer in the development environment.

<img width="1916" height="1020" alt="Image" src="https://github.com/user-attachments/assets/d7aef868-b36a-4037-8a43-7ebe8392242e" />
<img width="1908" height="1022" alt="Image" src="https://github.com/user-attachments/assets/f03171df-f7a2-4a38-b521-fcaf27a6ac35" />

I believe this is a condition of Strict Mode's double mount and not actually an issue. I see that the code already handles and expects these errors, but it logs them regardless.

The proposed change is to move `console.error` calls inside the `if (mounted)` checks, unless there is a non-apparent reason why it should always be logged.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Create new project, load audio file and create audio layer
- [X] Open existing project with an audio layer

**Test Configuration**:
* Node version: v22.13.1
* Browser (if applicable): Chrome 139.0.7258.138
* Operating System: Ubuntu 24.04.1

## Screenshots (if applicable)
<img width="1917" height="1018" alt="image" src="https://github.com/user-attachments/assets/a67b1c1e-0404-4655-84f3-d4a421f4f375" />


## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have added screenshots if ui has been changed
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
