### PR TITLE
docs: use GitHub flavoured markdown for note in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
       <img src="apps/web/public/logo.png" alt="OpenCut Logo" width="100" />
     </td>
     <td align="right">
-      <h1>OpenCut</span></h1>
+      <h1>OpenCut</h1>
       <h3 style="margin-top: -10px;">A free, open-source video editor for web, desktop, and mobile.</h3>
     </td>
   </tr>
@@ -45,7 +45,7 @@ Before you begin, ensure you have the following installed on your system:
   (for `npm` alternative)
 - [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)
 
-> [!Note]
+> [!NOTE]
 > Docker is optional, but it's essential for running the local database and Redis services. If you're planning to run the frontend or want to contribute to frontend features, you can skip the Docker setup. If you have followed the steps below in [Setup](#setup), you're all set to go!
 
 ### Setup


### PR DESCRIPTION

<img width="861" height="152" alt="image" src="https://github.com/user-attachments/assets/51865039-2280-410a-b055-76c7b98e3501" />


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added screenshots if ui has been changed
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed README formatting to restore the main header and improve presentation.
  * Reformatted the “Docker is optional” note into a highlighted admonition for clearer visibility.
  * No functional changes; content unchanged aside from presentation—improves onboarding clarity without altering workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->