### PR TITLE
feat(ui): implement if-else statement to toggle theme icon

### DIFF
--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -18,8 +18,11 @@ export function ThemeToggle({ className }: ThemeToggleProps) {
       className="h-7"
       onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
     >
-      <Sun className="!size-[1.1rem]" />
-      <span className="sr-only">{theme === "dark" ? "Light" : "Dark"}</span>
+      {theme === "light" ? (
+        <Sun className="!size-[1.1rem]" aria-hidden="true" />
+      ) : (
+        <Moon className="!size-[1.1rem]" aria-hidden="true" />
+      )}
     </Button>
   );
 }


### PR DESCRIPTION
## Description

wrote if else statement to change icon of theme on main page

#618 

## Type of change

Please delete options that are not relevant.

- [+] Bug fix (non-breaking change which fixes an issue)
- [+] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Tests

## How Has This Been Tested?
i manually tested it, on my local machine

**Test Configuration**:
* Node version:  22
* Browser (if applicable): Chrome Canary
* Operating System: Windows 11



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Theme toggle icon now correctly reflects the active theme: Sun for light mode and Moon for dark mode, improving visual clarity for users.

* **Style**
  * Simplified the theme toggle by removing the hidden descriptive text and relying solely on the icon as the visual indicator, keeping layout and interaction unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->