### PR TITLE
Fix/toggle theme hydration error

### DIFF
--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -22,8 +22,8 @@ export function Header() {
   );
 
   const rightContent = (
-    <nav className="flex items-center gap-2">
-      <div className="flex items-center gap-4">
+    <nav className="flex items-center gap-1 justify-center">
+      <div className="flex items-center gap-3">
         <Link href="/blog">
           <Button variant="text" className="text-sm p-0">
             Blog

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -27,7 +27,7 @@ export function ThemeToggle({ className }: ThemeToggleProps) {
           onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
         >
           {theme === "dark" ? <Sun className="!size-[1.1rem]" /> : <Moon className="!size-[1.1rem]" />}
-          {/* <span className="sr-only">{theme === "dark" ? "Light" : "Dark"}</span> */}
+          <span className="sr-only">{theme === "dark" ? "Light" : "Dark"}</span>
         </Button>
       } 
     </>

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -1,8 +1,8 @@
 "use client";
-
 import { Button } from "./ui/button";
 import { Sun, Moon } from "lucide-react";
 import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
 
 interface ThemeToggleProps {
   className?: string;
@@ -10,16 +10,26 @@ interface ThemeToggleProps {
 
 export function ThemeToggle({ className }: ThemeToggleProps) {
   const { theme, setTheme } = useTheme();
+  const [isClient, setIsClient] = useState(false);
 
+  useEffect(() => {
+    setIsClient(true)
+  }, []) // this will see that the client side is rendered or not.
+  
+  // if the client side is rendered then only render the button
   return (
-    <Button
-      size="icon"
-      variant="text"
-      className="h-7"
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-    >
-      {theme === "dark" ? <Sun className="!size-[1.1rem]" /> : <Moon className="!size-[1.1rem]" />}
-      {/* <span className="sr-only">{theme === "dark" ? "Light" : "Dark"}</span> */}
-    </Button>
+    <>
+      {
+        isClient && <Button
+          size="icon"
+          variant="text"
+          className="h-7"
+          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+        >
+          {theme === "dark" ? <Sun className="!size-[1.1rem]" /> : <Moon className="!size-[1.1rem]" />}
+          {/* <span className="sr-only">{theme === "dark" ? "Light" : "Dark"}</span> */}
+        </Button>
+      } 
+    </>
   );
 }

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -18,8 +18,8 @@ export function ThemeToggle({ className }: ThemeToggleProps) {
       className="h-7"
       onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
     >
-      <Sun className="!size-[1.1rem]" />
-      <span className="sr-only">{theme === "dark" ? "Light" : "Dark"}</span>
+      {theme === "dark" ? <Sun className="!size-[1.1rem]" /> : <Moon className="!size-[1.1rem]" />}
+      {/* <span className="sr-only">{theme === "dark" ? "Light" : "Dark"}</span> */}
     </Button>
   );
 }


### PR DESCRIPTION
fix: prevent hydration error in ThemeToggle (Fixes #610)
Description

This PR resolves a React hydration mismatch error that occurs during initial page load when rendering the ThemeToggle component.

The issue occurred because the theme context (useTheme from next-themes) attempted to read from localStorage during the first render. Since localStorage is only available in the browser, the server-rendered HTML mismatched the client-rendered output, causing hydration errors.

Technical Solution

Implemented the “wait until mounted” pattern in ThemeToggle.tsx:

Added const [isClient, setIsClient] = useState(false).

Used useEffect to update setIsClient(true) after the component mounts.

Conditionally rendered the theme toggle button:

{isClient && <Button>...</Button>}


Ensures the button and theme icons only render on the client, eliminating hydration errors.

Motivation and Context

Prevents hydration warnings/errors in the console.

Ensures a smoother user experience without flicker or mismatched UI.

Improves code clarity by explicitly separating SSR and client-only logic.

Screenshots

Before (hydration error present):
<img width="1302" height="777" alt="Screenshot 2025-09-27 190825" src="https://github.com/user-attachments/assets/1cfeb966-1808-49f1-8361-7ee6f2f64406" />

After (hydration fixed):
<img width="669" height="345" alt="Screenshot 2025-09-27 190914" src="https://github.com/user-attachments/assets/75a84ac6-5546-4c4d-ae0c-28eea1040ba2" />

and there was bug in the responsiveness of navbar which was overflowing on 320px 
which was fixed
Before
<img width="506" height="172" alt="image" src="https://github.com/user-attachments/assets/5d9495d1-1c06-44bd-9f80-69017f569849" />
After
<img width="438" height="120" alt="image" src="https://github.com/user-attachments/assets/859f9541-dac1-41ca-b045-1f29f5899835" />

Type of Change

 Bug fix (non-breaking change which fixes an issue)

 Code refactoring

How Has This Been Tested?

Steps to Reproduce & Verify Fix:

Run bun run dev.

Open the app in browser.

Perform a hard refresh (Ctrl/Cmd + Shift + R).

✅ Verify that no hydration errors (Hydration failed / Expected server HTML…) appear in the console.

✅ Confirm that the theme toggle button appears and works (light ↔ dark mode).

Test Environment:

Node.js: [v22.14.0]

Browser: [Brave 1.8.12]

OS: [Windows]

Checklist

 My code follows the project style guidelines

 Self-reviewed my code

 Added screenshots if UI has changed

 Commented code where necessary

 Updated documentation if needed

 No new warnings introduced

 Verified fix with manual console check

 Existing tests pass locally
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Theme toggle now dynamically displays Sun or Moon icons based on the current theme.

- Bug Fixes
  - Prevents hydration mismatch by rendering the toggle only after the page mounts, reducing initial icon flicker.

- Style
  - Header right-side spacing and centering updated for improved horizontal alignment.

- Accessibility
  - Screen-reader label for the toggle preserved to maintain accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->