### PR TITLE
feat(editor): Add visual Undo/Redo buttons & Fix tooltip visibility

### DIFF
--- a/apps/web/src/components/editor/timeline/timeline-toolbar.tsx
+++ b/apps/web/src/components/editor/timeline/timeline-toolbar.tsx
@@ -27,6 +27,8 @@ import {
   SplitSquareHorizontal,
   Scissors,
   LayersIcon,
+  Undo2,
+  Redo2,
 } from "lucide-react";
 import {
   SplitButton,
@@ -63,6 +65,10 @@ export function TimelineToolbar({
     toggleSnapping,
     rippleEditingEnabled,
     toggleRippleEditing,
+    undo,
+    redo,
+    history,
+    redoStack,
   } = useTimelineStore();
   const { currentTime, duration, isPlaying, toggle, seek } = usePlaybackStore();
   const { toggleBookmark, isBookmarked, activeProject } = useProjectStore();
@@ -174,10 +180,41 @@ export function TimelineToolbar({
   };
 
   const currentBookmarked = isBookmarked(currentTime);
+
   return (
     <div className="flex items-center justify-between px-2 py-1 border-b h-10">
       <div className="flex items-center gap-1">
         <TooltipProvider delayDuration={500}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="text"
+                size="icon"
+                onClick={undo}
+                disabled={history.length === 0}
+                className={history.length === 0 ? "opacity-30" : ""}
+              >
+                <Undo2 className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Undo (Ctrl+Z)</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="text"
+                size="icon"
+                onClick={redo}
+                disabled={redoStack.length === 0}
+                className={redoStack.length === 0 ? "opacity-30" : ""}
+              >
+                <Redo2 className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Redo (Ctrl+Y)</TooltipContent>
+          </Tooltip>
+          <div className="w-px h-6 bg-border mx-1" />
+
           <Tooltip>
             <TooltipTrigger asChild>
               <Button variant="text" size="icon" onClick={toggle}>

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -11,7 +11,7 @@ const Tooltip = TooltipPrimitive.Root;
 const TooltipTrigger = TooltipPrimitive.Trigger;
 
 const tooltipVariants = cva(
-  'z-50 overflow-visible rounded-sm text-sm shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+  'z-1000 overflow-visible rounded-sm text-sm shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Description

This PR improves the Timeline accessibility and UX by introducing **visual Undo/Redo buttons** to the toolbar. Previously, these actions were restricted to keyboard shortcuts (`Ctrl+Z`/`Ctrl+Y`).

While implementing this feature, I identified a UI issue where tooltips in the timeline were being obscured by the track headers (due to conflicting `z-index` layering). Consequently, this PR also includes a fix for the `Tooltip` component to ensure it properly renders above all editor layers.

**Changes included:**
1.  Added `Undo` and `Redo` buttons to `TimelineToolbar`.
2.  Integrated logic to disable buttons when history/redo stack is empty.
3.  **UI Fix:** Increased `Tooltip` component `z-index` from `50` to `1000` to prevent them from being clipped by the Track Header (`z-100`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring

## How Has This Been Tested?

1.  **Functional Test:**
    *   Opened a project in the Editor.
    *   Performed actions (move clip, split clip).
    *   Verified "Undo" button becomes enabled and reverts action on click.
    *   Verified "Redo" button becomes enabled and reapplies action on click.
2.  **UI/Regression Test:**
    *   Hovered over the new buttons (located near the left edge).
    *   **Success:** Confirmed the tooltip now renders *on top* of the Track Header panel without being obscured (see screenshots).

**Test Configuration**:
* Node version: v18+ (Bun)
* Browser: Chrome / Edge

## Screenshots

### 1. New Feature: Undo/Redo Buttons
<img width="238" height="174" alt="Undo/Redo Buttons" src="https://github.com/user-attachments/assets/3af8aa64-734a-485c-ba71-3c60581c8627" />

### 2. Bug Fix: Tooltip Layering
*Before this fix, the tooltip text was cut off by the track panel.*
<img width="161" height="110" alt="Tooltip Z-Index Fix" src="https://github.com/user-attachments/assets/c445d494-fd9a-471d-b875-055f450de14f" />

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added screenshots if ui has been changed
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Undo and Redo buttons to the timeline editor toolbar, enabling users to reverse and restore recent actions. Buttons automatically disable when no history is available.

* **Bug Fixes**
  * Improved tooltip layering to ensure proper visibility over interface elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->