### PR TITLE
docs: complete Code of Conduct enforcement guidelines

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -79,6 +79,38 @@ unprofessional or unwelcome in the community.
 clarity around the nature of the violation and an explanation of why the
 behavior was inappropriate. A public apology may be requested.
 
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],


### PR DESCRIPTION
## Summary

This PR completes the Code of Conduct by adding the missing enforcement guideline sections.

### Changes Made

The Code of Conduct file was incomplete - it only had section 1 of the Enforcement Guidelines. This PR adds the missing sections from the Contributor Covenant v2.1:

- **Section 2: Warning** - Consequences for violations through a single incident or series of actions
- **Section 3: Temporary Ban** - Consequences for serious violations of community standards
- **Section 4: Permanent Ban** - Consequences for demonstrating a pattern of violations

### Why This Matters

A complete Code of Conduct:
- Provides clear, graduated consequences for community violations
- Ensures consistency with the Contributor Covenant standard that OpenCut adopted
- Helps community leaders make fair enforcement decisions
- Sets clear expectations for community members

### Verification

The added content matches the official [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html) template, which is already referenced in the Attribution section.

---

**Note:** Documentation-only change. No code modifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Code of Conduct with expanded enforcement guidelines, including Warning, Temporary Ban, and Permanent Ban procedures with detailed community impact descriptions.
  * Updated to Contributor Covenant version 2.1.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->