### PR TITLE
docs: add Discord server link to SUPPORT.md

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -12,7 +12,8 @@ Thanks for using OpenCut! If you need help, here are your options:
 - **Questions**: Use GitHub Discussions for general questions
 
 ## Community
-- Join our discussions on GitHub
+- **Discord**: Join our [Discord server](https://discord.gg/zmR9N35cjK) for real-time help and discussions
+- **GitHub Discussions**: Ask questions and share ideas
 - Follow the [Code of Conduct](CODE_OF_CONDUCT.md)
 
 ## Response Times


### PR DESCRIPTION
## Summary

This PR adds the Discord server link to the SUPPORT.md file for consistency with other documentation.

### Changes Made

Added Discord server information to the Community section of SUPPORT.md with:
- Direct link to the Discord server (https://discord.gg/zmR9N35cjK)
- Clear description indicating it's for "real-time help and discussions"
- Better organization of community resources

### Why This Change?

The Discord server is already mentioned in:
- CONTRIBUTING.md (line 63) - for asking questions about contribution areas
- CODE_OF_CONDUCT.md (line 62) - for reporting violations

However, it was missing from SUPPORT.md, which is specifically meant to help users find support resources. This creates an inconsistency where users checking the support documentation wouldn't know about the Discord option.

### Impact

Users looking for help will now have a complete list of available support channels, including the real-time option of Discord.

---

**Note:** Documentation-only change. No code modifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Discord as a new official community channel for peer support and discussions
  * Updated community resources with Discord and GitHub Discussions as primary support channels

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->