### PR TITLE
fix: correct Better Auth URL variable in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
     environment:
       - NODE_ENV=production
       - DATABASE_URL=postgresql://opencut:opencutthegoat@db:5432/opencut
-      - BETTER_AUTH_URL=http://localhost:3000
+      - NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3000
       - BETTER_AUTH_SECRET=your-production-secret-key-here
       - UPSTASH_REDIS_REST_URL=http://serverless-redis-http:80
       - UPSTASH_REDIS_REST_TOKEN=example_token


### PR DESCRIPTION
## Summary

This PR fixes an environment variable name mismatch in docker-compose.yaml that would cause authentication to fail in Docker deployments.

### The Problem

The `docker-compose.yaml` file uses `BETTER_AUTH_URL`, but the actual codebase expects `NEXT_PUBLIC_BETTER_AUTH_URL`.

**Evidence:**
- `packages/auth/src/server.ts` (lines 8 and 45) reads `NEXT_PUBLIC_BETTER_AUTH_URL`
- `apps/web/.env.example` uses `NEXT_PUBLIC_BETTER_AUTH_URL`
- All documentation (README.md, CONTRIBUTING.md) specifies `NEXT_PUBLIC_BETTER_AUTH_URL`

### Changes Made

Changed line 62 in docker-compose.yaml:
```diff
- BETTER_AUTH_URL=http://localhost:3000
+ NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3000
```

### Impact

Without this fix, users deploying with Docker would encounter authentication failures because the Better Auth library wouldn't be able to find its base URL configuration.

### Testing

This can be verified by:
1. Checking `packages/auth/src/server.ts` - it destructures `NEXT_PUBLIC_BETTER_AUTH_URL` from keys()
2. Checking the Better Auth configuration - it uses `baseURL: NEXT_PUBLIC_BETTER_AUTH_URL`

---

**Note:** This is a configuration fix that aligns docker-compose.yaml with the actual codebase requirements.