### PR TITLE
feat(timeline): add Ctrl+X cut shortcut for timeline elements

### DIFF
--- a/apps/web/src/constants/actions.ts
+++ b/apps/web/src/constants/actions.ts
@@ -47,7 +47,8 @@ export type Action =
   | "undo" // Undo last action
   | "redo" // Redo last undone action
   | "copy-selected" // Copy selected elements to clipboard
-  | "paste-selected"; // Paste elements from clipboard at playhead
+  | "paste-selected" // Paste elements from clipboard at playhead
+  | "cut-selected"; // Cut selected elements (copy + delete)
 
 /**
  * Defines the arguments, if present for a given type that is required to be passed on

--- a/apps/web/src/hooks/use-editor-actions.ts
+++ b/apps/web/src/hooks/use-editor-actions.ts
@@ -207,6 +207,16 @@ export function useEditorActions() {
   );
 
   useActionHandler(
+    "cut-selected",
+    () => {
+      if (selectedElements.length === 0) return;
+      useTimelineStore.getState().copySelected();
+      deleteSelected();
+    },
+    undefined
+  );
+
+  useActionHandler(
     "paste-selected",
     () => {
       useTimelineStore.getState().pasteAtTime(currentTime);

--- a/apps/web/src/hooks/use-keyboard-shortcuts-help.ts
+++ b/apps/web/src/hooks/use-keyboard-shortcuts-help.ts
@@ -67,6 +67,10 @@ const actionDescriptions: Record<
     description: "Copy selected elements",
     category: "Editing",
   },
+  "cut-selected": {
+    description: "Cut selected elements",
+    category: "Editing",
+  },
   "paste-selected": {
     description: "Paste elements at playhead",
     category: "Editing",

--- a/apps/web/src/stores/keybindings-store.ts
+++ b/apps/web/src/stores/keybindings-store.ts
@@ -24,6 +24,7 @@ export const defaultKeybindings: KeybindingConfig = {
   "ctrl+a": "select-all",
   "ctrl+d": "duplicate-selected",
   "ctrl+c": "copy-selected",
+  "ctrl+x": "cut-selected",
   "ctrl+v": "paste-selected",
   "ctrl+z": "undo",
   "ctrl+shift+z": "redo",


### PR DESCRIPTION
## Summary
- Added `Ctrl+X` keybinding for cut functionality (copy + delete)
- New "cut-selected" action that copies selected elements to clipboard then deletes them
- Added keyboard shortcut help entry

## Related Issue
Partially addresses #672

### Note on Drag/Drop Between Tracks
After investigating the codebase, **cross-track drag/drop is already implemented**:
- `moveElementToTrack()` function exists in timeline-store.ts
- Used in timeline-track.tsx for drag operations
- Elements can be dragged from one track to another

If drag/drop between tracks isn't working for some users, it may be:
1. A browser-specific issue
2. A regression in a specific version
3. User may not be aware of the feature

Would appreciate confirmation from maintainers on whether additional work is needed for cross-track drag/drop.

## Test plan
- [x] Select element on timeline
- [x] Press Ctrl+X (or Cmd+X on Mac)
- [x] Element is copied to clipboard AND deleted
- [x] Ctrl+V pastes the element at playhead position
- [x] Keyboard shortcuts help shows new shortcut

🤖 Generated with [Claude Code](https://claude.ai/code)