### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/bun-ci.yml
+++ b/.github/workflows/bun-ci.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
@@ -38,7 +38,7 @@ jobs:
           bun-version: 1.2.18
 
       - name: Cache Bun modules
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.2.18-${{ hashFiles('apps/web/bun.lock') }}

--- a/.github/workflows/bun-ci.yml
+++ b/.github/workflows/bun-ci.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
@@ -38,7 +38,7 @@ jobs:
           bun-version: 1.2.18
 
       - name: Cache Bun modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.2.18-${{ hashFiles('apps/web/bun.lock') }}


### PR DESCRIPTION
- [ ] I've opened an issue first  
- [ ] This was approved by a maintainer  
- **Description:** This PR updates outdated GitHub Action versions.  
  - Updated `actions/cache` from `v4` to `v5` in `.github/workflows/bun-ci.yml`  
  - Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/bun-ci.yml`  
- **Testing:** The changes will be tested in the CI pipeline of the pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration steps for repository checkout and dependency caching to newer, more secure and compatible versions to keep CI running reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->