### PR TITLE
fix: replace outer <button> with <div> in TimelineTrackContent to res…

### DIFF
--- a/apps/web/src/components/editor/panels/timeline/timeline-track.tsx
+++ b/apps/web/src/components/editor/panels/timeline/timeline-track.tsx
@@ -63,7 +63,7 @@ export function TimelineTrackContent({
 	});
 
 	return (
-		<button
+		<div
 			className="size-full"
 			onClick={(event) => {
 				if (shouldIgnoreClick?.()) return;
@@ -74,7 +74,6 @@ export function TimelineTrackContent({
 				event.preventDefault();
 				onTrackMouseDown?.(event);
 			}}
-			type="button"
 		>
 			<div className="relative h-full min-w-full">
 				{track.elements.length === 0 ? (
@@ -107,6 +106,6 @@ export function TimelineTrackContent({
 					})
 				)}
 			</div>
-		</button>
+		</div>
 	);
 }


### PR DESCRIPTION
…olve nested button hydration error

TimelineTrackContent wrapped its entire content in a <button>, while each timeline element (ElementInner) also rendered its own <button> for click handling. This created an invalid HTML structure where <button> was nested inside <button>, triggering a React hydration error:

  "In HTML, <button> cannot be a descendant of <button>."

The outer <button> in TimelineTrackContent only handled click-to-deselect and mousedown events — it did not need button semantics. Replacing it with a <div> preserves the exact same event handling behavior while eliminating the invalid nesting.

⚠️ READ BEFORE SUBMITTING ⚠️

We are not currently accepting PRs except for critical bugs.

If this is a bug fix:
- [ ] I've opened an issue first
- [ ] This was approved by a maintainer

If this is a feature:

This PR will be closed. Please open an issue to discuss first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal component structure for improved maintainability.

---

**Note:** This release contains primarily internal improvements with no user-facing changes to functionality or interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->