### PR TITLE
fix(docker): allow MARBLE_WORKSPACE_KEY to be passed during build

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 
 ARG FREESOUND_CLIENT_ID
 ARG FREESOUND_API_KEY
+ARG MARBLE_WORKSPACE_KEY
 
 COPY package.json package.json
 COPY bun.lock bun.lock
@@ -31,7 +32,7 @@ ENV UPSTASH_REDIS_REST_URL="http://localhost:8079"
 ENV UPSTASH_REDIS_REST_TOKEN="example_token"
 ENV NEXT_PUBLIC_SITE_URL="http://localhost:3000"
 ENV NEXT_PUBLIC_MARBLE_API_URL="https://api.marblecms.com"
-ENV MARBLE_WORKSPACE_KEY="build-placeholder"
+ENV MARBLE_WORKSPACE_KEY=${MARBLE_WORKSPACE_KEY:-cmd4iw9mm0006l804kwqv0k46}
 ENV CLOUDFLARE_ACCOUNT_ID="build-placeholder"
 ENV R2_ACCESS_KEY_ID="build-placeholder"
 ENV R2_SECRET_ACCESS_KEY="build-placeholder"


### PR DESCRIPTION
This PR fixes the Docker build failure during the next build stage.
The Problem:
The Dockerfile previously used a hardcoded "build-placeholder" for MARBLE_WORKSPACE_KEY. Since Next.js performs static generation during build time, it attempts to fetch blog data. An invalid key results in a 404 Not Found error, causing the build to fail.
The Solution:

Added ARG MARBLE_WORKSPACE_KEY to the Dockerfile.

Changed ENV MARBLE_WORKSPACE_KEY to use the passed argument with a working default value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build configuration for improved environment variable handling.

**Note:** This is an infrastructure update with no end-user visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->