### PR TITLE
Fix OpenCut logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <table width="100%">
   <tr>
     <td align="left" width="120">
-      <img src="apps/web/public/logos/opencut/1k/logo-white-black.png" alt="OpenCut Logo" width="100" />
+      <img src="apps/web/public/logos/opencut/icon.svg" alt="OpenCut Logo" width="100" />
     </td>
     <td align="right">
       <h1>OpenCut</span></h1>


### PR DESCRIPTION
ik that this isn't a critical bug, but the logo wasn't showing in the readme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project header image reference in README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->