### PR TITLE
fix: add error handling to async clipboard handler in header.tsx

### DIFF
--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -68,8 +68,11 @@ export function Header() {
 							<ContextMenuItem
 								onClick={async () => {
 									try {
-										const res = await fetch(DEFAULT_LOGO_URL);
-										const svg = await res.text();
+										const response = await fetch(DEFAULT_LOGO_URL);
+										if (!response.ok) {
+											throw new Error(`Failed to fetch SVG: ${response.status}`);
+										}
+										const svg = await response.text();
 										await navigator.clipboard.writeText(svg);
 										toast.success("SVG copied to clipboard");
 									} catch {

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -23,6 +23,7 @@ import {
 	ContextMenuItem,
 	ContextMenuTrigger,
 } from "./ui/context-menu";
+import { toast } from "sonner";
 
 export function Header() {
 	const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -66,9 +67,14 @@ export function Header() {
 						<ContextMenuContent>
 							<ContextMenuItem
 								onClick={async () => {
-									const res = await fetch(DEFAULT_LOGO_URL);
-									const svg = await res.text();
-									await navigator.clipboard.writeText(svg);
+									try {
+										const res = await fetch(DEFAULT_LOGO_URL);
+										const svg = await res.text();
+										await navigator.clipboard.writeText(svg);
+										toast.success("SVG copied to clipboard");
+									} catch {
+										toast.error("Failed to copy SVG to clipboard");
+									}
 								}}
 							>
 								<HugeiconsIcon icon={Copy01Icon} />


### PR DESCRIPTION
## Summary

Fixes #722

The async `onClick` handler for copying the SVG logo had three unhandled promise rejections with no user feedback on failure.

- Wrap `fetch()`, `res.text()`, and `navigator.clipboard.writeText()` in a `try-catch` block
- Show `toast.success` on successful copy
- Show `toast.error` if any step fails

## Test plan

- [ ] Right-click the OpenCut logo in the header
- [ ] Click "Copy SVG" — confirm success toast appears and SVG is in clipboard
- [ ] Test in a browser that blocks clipboard access — confirm error toast appears instead of silent failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-facing toast notifications for SVG copy actions (success and error).

* **Bug Fixes**
  * Improved SVG copy behavior with robust error handling and clearer feedback when the copy fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->