### PR TITLE
feat(effects+transforms): 24 effects, clip transforms, and animated presets

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "@hugeicons/core-free-icons": "^3.1.1",
     "@hugeicons/react": "^1.1.6",
     "@huggingface/transformers": "^3.8.1",
+    "@mediapipe/face_mesh": "0.4.1657299874",
     "@opencut/env": "workspace:*",
     "@opencut/ui": "workspace:*",
     "@opennextjs/cloudflare": "^1.18.0",

--- a/apps/web/src/components/editor/panels/assets/index.tsx
+++ b/apps/web/src/components/editor/panels/assets/index.tsx
@@ -10,6 +10,7 @@ import { SoundsView } from "./views/sounds";
 import { StickersView } from "./views/stickers";
 import { TextView } from "./views/text";
 import { EffectsView } from "./views/effects";
+import { TransformsView } from "./views/transforms";
 
 export function AssetsPanel() {
 	const { activeTab } = useAssetsPanelStore();
@@ -20,11 +21,7 @@ export function AssetsPanel() {
 		text: <TextView />,
 		stickers: <StickersView />,
 		effects: <EffectsView />,
-		transitions: (
-			<div className="text-muted-foreground p-4">
-				Transitions view coming soon...
-			</div>
-		),
+		transitions: <TransformsView />,
 		captions: <Captions />,
 		filters: (
 			<div className="text-muted-foreground p-4">

--- a/apps/web/src/components/editor/panels/assets/views/transforms.tsx
+++ b/apps/web/src/components/editor/panels/assets/views/transforms.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import { PanelView } from "@/components/editor/panels/assets/views/base-panel";
+import { DraggableItem } from "@/components/editor/panels/assets/draggable-item";
+import {
+	transformsRegistry,
+	TRANSFORM_TARGET_ELEMENT_TYPES,
+} from "@/lib/transforms";
+import { getAllPresets } from "@/lib/transforms/presets/registry";
+import { transformPreviewService } from "@/services/renderer/transform-preview";
+import { useEditor } from "@/hooks/use-editor";
+import { useElementSelection } from "@/hooks/timeline/element/use-element-selection";
+import { isTransformableElement } from "@/lib/timeline";
+import type { TransformDefinition } from "@/lib/transforms/types";
+import type { TransformPreset } from "@/lib/transforms/presets/types";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { MagicWand05Icon } from "@hugeicons/core-free-icons";
+
+/**
+ * Transforms library grid. Repurposes the "transitions" assets-panel tab
+ * slot (previously a "coming soon" placeholder) since there is no
+ * dedicated tab for the spatial/visual transform library — it is the
+ * closest semantic match to clip-transforms/effects. See
+ * `stores/assets-panel-store.tsx` TAB_KEYS and `assets/index.tsx`.
+ *
+ * Unlike effects (which can be standalone timeline elements), transforms
+ * only attach to an existing transformable clip, so clicking an item adds
+ * it to the currently selected element rather than inserting a new one.
+ */
+export function TransformsView() {
+	const transforms = transformsRegistry
+		.getAll()
+		.filter((definition) => definition.category !== "transition");
+	const presets = getAllPresets();
+
+	return (
+		<PanelView title="Transforms">
+			{presets.length > 0 && (
+				<div className="flex flex-col gap-2 pb-4">
+					<p className="text-xs text-muted-foreground font-medium px-0.5">
+						Animated Presets
+					</p>
+					<PresetsGrid presets={presets} />
+				</div>
+			)}
+			<TransformsGrid transforms={transforms} />
+		</PanelView>
+	);
+}
+
+function PresetsGrid({ presets }: { presets: TransformPreset[] }) {
+	return (
+		<div
+			className="grid gap-2"
+			style={{ gridTemplateColumns: "repeat(auto-fill, minmax(96px, 1fr))" }}
+		>
+			{presets.map((preset) => (
+				<PresetItem key={preset.type} preset={preset} />
+			))}
+		</div>
+	);
+}
+
+/**
+ * Applies a keyframe-animated transform preset (e.g. Ken Burns) to the
+ * currently selected clip. Unlike a single `TransformItem`, this adds one
+ * or more `ClipTransform` instances AND writes animation channels
+ * (`clipTransforms.<id>.params.<key>`) driven by the preset's keyframe
+ * data — see `ApplyTransformPresetCommand`.
+ */
+function PresetItem({ preset }: { preset: TransformPreset }) {
+	const editor = useEditor();
+	const { selectedElements } = useElementSelection();
+
+	const handleApplyToSelectedClip = useCallback(() => {
+		const target = selectedElements[0];
+		if (!target) return;
+
+		const elementsWithTracks = editor.timeline.getElementsWithTracks({
+			elements: [target],
+		});
+		const elementWithTrack = elementsWithTracks[0];
+		if (
+			!elementWithTrack ||
+			!isTransformableElement(elementWithTrack.element)
+		) {
+			return;
+		}
+
+		editor.timeline.applyTransformPreset({
+			trackId: target.trackId,
+			elementId: target.elementId,
+			presetType: preset.type,
+		});
+	}, [editor, selectedElements, preset.type]);
+
+	const preview = (
+		<div className="flex size-full items-center justify-center bg-muted/40">
+			<HugeiconsIcon
+				icon={MagicWand05Icon}
+				className="size-6 text-muted-foreground"
+			/>
+		</div>
+	);
+
+	return (
+		<DraggableItem
+			name={preset.name}
+			preview={preview}
+			dragData={{
+				id: preset.type,
+				name: preset.name,
+				type: "effect",
+				effectType: preset.type,
+				targetElementTypes: TRANSFORM_TARGET_ELEMENT_TYPES,
+			}}
+			isDraggable={false}
+			onAddToTimeline={handleApplyToSelectedClip}
+			aspectRatio={1}
+			isRounded
+			variant="card"
+			containerClassName="w-full"
+		/>
+	);
+}
+
+function TransformsGrid({ transforms }: { transforms: TransformDefinition[] }) {
+	return (
+		<div
+			className="grid gap-2"
+			style={{ gridTemplateColumns: "repeat(auto-fill, minmax(96px, 1fr))" }}
+		>
+			{transforms.map((transform) => (
+				<TransformItem key={transform.type} transform={transform} />
+			))}
+		</div>
+	);
+}
+
+function TransformPreviewCanvas({ transformType }: { transformType: string }) {
+	const canvasRef = useRef<HTMLCanvasElement>(null);
+
+	useEffect(() => {
+		const render = () => {
+			if (canvasRef.current) {
+				transformPreviewService.renderPreview({
+					transformType,
+					params: {},
+					targetCanvas: canvasRef.current,
+				});
+			}
+		};
+
+		render();
+		return transformPreviewService.onPreviewImageReady({ callback: render });
+	}, [transformType]);
+
+	return <canvas ref={canvasRef} className="size-full" />;
+}
+
+function TransformItem({ transform }: { transform: TransformDefinition }) {
+	const editor = useEditor();
+	const { selectedElements } = useElementSelection();
+
+	const handleAddToSelectedClip = useCallback(() => {
+		// currentTime is unused — transforms attach to the selected clip,
+		// not inserted at the playhead like standalone effect elements.
+		const target = selectedElements[0];
+		if (!target) return;
+
+		const elementsWithTracks = editor.timeline.getElementsWithTracks({
+			elements: [target],
+		});
+		const elementWithTrack = elementsWithTracks[0];
+		if (
+			!elementWithTrack ||
+			!isTransformableElement(elementWithTrack.element)
+		) {
+			return;
+		}
+
+		editor.timeline.addClipTransform({
+			trackId: target.trackId,
+			elementId: target.elementId,
+			transformType: transform.type,
+		});
+	}, [editor, selectedElements, transform.type]);
+
+	const preview = <TransformPreviewCanvas transformType={transform.type} />;
+
+	// Not draggable-onto-timeline: transforms only attach to an existing
+	// transformable clip (no standalone track type), unlike effects. The
+	// timeline drag/drop handler (use-timeline-drag-drop.ts) has no case
+	// for "attach to selected element" — extending it is out of scope
+	// here, so this card is click-to-add only. `dragData` is required by
+	// DraggableItem's props but is never read because `isDraggable={false}`
+	// disables the drag handlers entirely.
+	return (
+		<DraggableItem
+			name={transform.name}
+			preview={preview}
+			dragData={{
+				id: transform.type,
+				name: transform.name,
+				type: "effect",
+				effectType: transform.type,
+				targetElementTypes: TRANSFORM_TARGET_ELEMENT_TYPES,
+			}}
+			isDraggable={false}
+			onAddToTimeline={handleAddToSelectedClip}
+			aspectRatio={1}
+			isRounded
+			variant="card"
+			containerClassName="w-full"
+		/>
+	);
+}

--- a/apps/web/src/components/editor/panels/properties/registry.tsx
+++ b/apps/web/src/components/editor/panels/properties/registry.tsx
@@ -7,6 +7,7 @@ import type {
 	RetimableElement,
 	StickerElement,
 	TextElement,
+	TransformableElement,
 	VisualElement,
 	VideoElement,
 	AudioElement,
@@ -27,6 +28,7 @@ import { BlendingTab } from "./tabs/blending-tab";
 import { AudioTab } from "./tabs/audio-tab";
 import { TextTab } from "./tabs/text-tab";
 import { ClipEffectsTab, StandaloneEffectTab } from "./tabs/effects-tab";
+import { ClipTransformsTab } from "./tabs/clip-transforms-tab";
 import { MasksTab } from "./tabs/masks-tab";
 import { SpeedTab } from "./tabs/speed-tab";
 import { GraphicTab } from "./tabs/graphic-tab";
@@ -132,6 +134,21 @@ function buildClipEffectsTab({
 	};
 }
 
+function buildClipTransformsTab({
+	element,
+}: {
+	element: TransformableElement;
+}): PropertiesTabDef {
+	return {
+		id: "clip-transforms",
+		label: "Warp",
+		icon: <HugeiconsIcon icon={ArrowExpandIcon} size={16} />,
+		content: ({ trackId }) => (
+			<ClipTransformsTab element={element} trackId={trackId} />
+		),
+	};
+}
+
 function buildTextTab({ element }: { element: TextElement }): PropertiesTabDef {
 	return {
 		id: "text",
@@ -150,7 +167,9 @@ function buildGraphicTab({
 		id: "graphic",
 		label: "Graphic",
 		icon: <OcShapesIcon size={16} />,
-		content: ({ trackId }) => <GraphicTab element={element} trackId={trackId} />,
+		content: ({ trackId }) => (
+			<GraphicTab element={element} trackId={trackId} />
+		),
 	};
 }
 
@@ -201,6 +220,7 @@ function getVideoConfig({
 			buildBlendingTab({ element }),
 			buildMasksTab({ element }),
 			buildClipEffectsTab({ element }),
+			buildClipTransformsTab({ element }),
 		],
 	};
 }
@@ -217,6 +237,7 @@ function getImageConfig({
 			buildBlendingTab({ element }),
 			buildMasksTab({ element }),
 			buildClipEffectsTab({ element }),
+			buildClipTransformsTab({ element }),
 		],
 	};
 }
@@ -232,6 +253,7 @@ function getStickerConfig({
 			buildTransformTab({ element }),
 			buildBlendingTab({ element }),
 			buildClipEffectsTab({ element }),
+			buildClipTransformsTab({ element }),
 		],
 	};
 }
@@ -249,6 +271,7 @@ function getGraphicConfig({
 			buildBlendingTab({ element }),
 			buildMasksTab({ element }),
 			buildClipEffectsTab({ element }),
+			buildClipTransformsTab({ element }),
 		],
 	};
 }

--- a/apps/web/src/components/editor/panels/properties/tabs/clip-transforms-tab.tsx
+++ b/apps/web/src/components/editor/panels/properties/tabs/clip-transforms-tab.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { useState } from "react";
+import type { ParamValues } from "@/lib/params";
+import type { ClipTransform } from "@/lib/transforms/types";
+import type { TransformableElement } from "@/lib/timeline";
+import { transformsRegistry } from "@/lib/transforms";
+import { useEditor } from "@/hooks/use-editor";
+import { useElementPreview } from "@/hooks/use-element-preview";
+import {
+	Section,
+	SectionContent,
+	SectionHeader,
+	SectionTitle,
+	SectionFields,
+} from "@/components/section";
+import { PropertyParamField } from "../components/property-param-field";
+import { Button } from "@/components/ui/button";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+	Delete02Icon,
+	ViewIcon,
+	ViewOffSlashIcon,
+	ArrowExpandIcon,
+} from "@hugeicons/core-free-icons";
+import { cn } from "@/utils/ui";
+import { Separator } from "@/components/ui/separator";
+import { useAssetsPanelStore } from "@/stores/assets-panel-store";
+
+/**
+ * Clip Transforms tab — lists spatial/visual clip transforms attached to
+ * the element and lets the user reorder, toggle, edit params, and remove
+ * them. Mirrors ClipEffectsTab (tabs/effects-tab.tsx) 1:1. Named
+ * "Clip Transforms" (not "Transform") to avoid colliding with the
+ * existing position/scale/rotate "Transform" tab (tabs/transform-tab.tsx).
+ */
+export function ClipTransformsTab({
+	element,
+	trackId,
+}: {
+	element: TransformableElement;
+	trackId: string;
+}) {
+	const [dragIndex, setDragIndex] = useState<number | null>(null);
+	const [dropIndex, setDropIndex] = useState<number | null>(null);
+	const editor = useEditor();
+	const { renderElement, previewUpdates, commit } = useElementPreview({
+		trackId,
+		elementId: element.id,
+		fallback: element,
+	});
+
+	const transforms: ClipTransform[] = element.clipTransforms ?? [];
+
+	const getRenderParams = ({
+		transformId,
+	}: {
+		transformId: string;
+	}): ParamValues => {
+		return (
+			(renderElement as TransformableElement).clipTransforms?.find(
+				(t) => t.id === transformId,
+			)?.params ??
+			transforms.find((t) => t.id === transformId)?.params ??
+			{}
+		);
+	};
+
+	const buildPreviewParam =
+		(transformId: string) =>
+		(key: string) =>
+		(value: number | string | boolean) => {
+			const updatedTransforms = (
+				(renderElement as TransformableElement).clipTransforms ?? []
+			).map((existing) =>
+				existing.id !== transformId
+					? existing
+					: { ...existing, params: { ...existing.params, [key]: value } },
+			);
+			previewUpdates({ clipTransforms: updatedTransforms });
+		};
+
+	const handleDragStart = ({ index }: { index: number }) => setDragIndex(index);
+
+	const handleDragOver = ({
+		event,
+		index,
+	}: {
+		event: React.DragEvent;
+		index: number;
+	}) => {
+		event.preventDefault();
+		if (index !== dropIndex) setDropIndex(index);
+	};
+
+	const handleDrop = ({ toIndex }: { toIndex: number }) => {
+		if (dragIndex !== null && dragIndex !== toIndex) {
+			editor.timeline.reorderClipTransforms({
+				trackId,
+				elementId: element.id,
+				fromIndex: dragIndex,
+				toIndex,
+			});
+		}
+		setDragIndex(null);
+		setDropIndex(null);
+	};
+
+	const handleDragEnd = () => {
+		setDragIndex(null);
+		setDropIndex(null);
+	};
+
+	return (
+		<div className="flex flex-col h-full">
+			<div className="border-b px-3.5 h-11 shrink-0 flex items-center">
+				<SectionTitle>Clip Transforms</SectionTitle>
+			</div>
+			{transforms.length === 0 ? (
+				<EmptyView />
+			) : (
+				<ul className="flex flex-col">
+					{transforms.map((transform, index) => {
+						const resolvedDragIndex = dragIndex ?? -1;
+						const isDragging = dragIndex === index;
+						const isDropTarget =
+							dropIndex === index && dragIndex !== null && dragIndex !== index;
+						const showTopDropIndicator =
+							isDropTarget && index < resolvedDragIndex;
+						const showBottomDropIndicator =
+							isDropTarget && index > resolvedDragIndex;
+
+						return (
+							<li
+								key={transform.id}
+								draggable
+								onDragStart={() => handleDragStart({ index })}
+								onDragOver={(event) => handleDragOver({ event, index })}
+								onDrop={() => handleDrop({ toIndex: index })}
+								onDragEnd={handleDragEnd}
+								className={cn(
+									"group list-none",
+									isDragging && "opacity-40",
+									showTopDropIndicator && "border-t-2 border-primary",
+									showBottomDropIndicator && "border-b-2 border-primary",
+								)}
+							>
+								<ClipTransformSection
+									transform={transform}
+									renderParams={getRenderParams({ transformId: transform.id })}
+									previewParam={buildPreviewParam(transform.id)}
+									onCommit={commit}
+									onToggle={() =>
+										editor.timeline.toggleClipTransform({
+											trackId,
+											elementId: element.id,
+											transformId: transform.id,
+										})
+									}
+									onRemove={() =>
+										editor.timeline.removeClipTransform({
+											trackId,
+											elementId: element.id,
+											transformId: transform.id,
+										})
+									}
+								/>
+							</li>
+						);
+					})}
+				</ul>
+			)}
+		</div>
+	);
+}
+
+function EmptyView() {
+	const setActiveTab = useAssetsPanelStore((s) => s.setActiveTab);
+
+	return (
+		<div className="flex flex-col h-full items-center justify-center gap-4 text-center">
+			<HugeiconsIcon
+				icon={ArrowExpandIcon}
+				className="size-10 text-muted-foreground"
+				strokeWidth={1}
+			/>
+			<div className="flex flex-col gap-2">
+				<h3 className="font-medium text-foreground">No clip transforms</h3>
+				<p className="text-muted-foreground text-sm text-balance max-w-44">
+					Add spatial or visual transforms to this layer from the Assets panel.
+				</p>
+			</div>
+			<Button
+				variant="default"
+				size="sm"
+				onClick={() => setActiveTab("transitions")}
+			>
+				Open transforms
+			</Button>
+		</div>
+	);
+}
+
+function ClipTransformSection({
+	transform,
+	renderParams,
+	previewParam,
+	onCommit,
+	onToggle,
+	onRemove,
+}: {
+	transform: ClipTransform;
+	renderParams: ParamValues;
+	previewParam: (key: string) => (value: number | string | boolean) => void;
+	onCommit: () => void;
+	onToggle?: () => void;
+	onRemove?: () => void;
+}) {
+	const definition = transformsRegistry.get(transform.type);
+
+	return (
+		<Section
+			sectionKey={onToggle ? `clip-transform:${transform.id}` : undefined}
+			showTopBorder={false}
+		>
+			<SectionHeader
+				className={cn(onToggle && "cursor-move")}
+				trailing={
+					onToggle && (
+						<div className="flex items-center gap-1">
+							<Button
+								variant={transform.enabled ? "secondary" : "ghost"}
+								size="icon"
+								aria-label={`Toggle ${definition.name}`}
+								onClick={onToggle}
+							>
+								<HugeiconsIcon
+									icon={transform.enabled ? ViewIcon : ViewOffSlashIcon}
+								/>
+							</Button>
+							<Button
+								variant="ghost"
+								size="icon"
+								aria-label={`Remove ${definition.name}`}
+								onClick={onRemove}
+							>
+								<HugeiconsIcon icon={Delete02Icon} />
+							</Button>
+						</div>
+					)
+				}
+			>
+				<SectionTitle
+					className={cn(
+						onToggle && !transform.enabled && "text-muted-foreground",
+					)}
+				>
+					{definition.name}
+				</SectionTitle>
+			</SectionHeader>
+			<SectionContent
+				className={cn("p-0", onToggle && !transform.enabled && "opacity-50")}
+			>
+				<SectionFields>
+					{definition.params.map((param) => (
+						<div key={param.key} className="flex flex-col gap-3.5">
+							<div className="px-4">
+								<PropertyParamField
+									param={param}
+									value={renderParams[param.key] ?? param.default}
+									onPreview={previewParam(param.key)}
+									onCommit={onCommit}
+								/>
+							</div>
+							<Separator />
+						</div>
+					))}
+				</SectionFields>
+			</SectionContent>
+		</Section>
+	);
+}

--- a/apps/web/src/core/index.ts
+++ b/apps/web/src/core/index.ts
@@ -10,6 +10,10 @@ import { AudioManager } from "./managers/audio-manager";
 import { SelectionManager } from "./managers/selection-manager";
 import { registerDefaultEffects } from "@/lib/effects";
 import { registerDefaultMasks } from "@/lib/masks";
+import {
+	registerDefaultPresets,
+	registerDefaultTransforms,
+} from "@/lib/transforms";
 
 export class EditorCore {
 	private static instance: EditorCore | null = null;
@@ -27,6 +31,8 @@ export class EditorCore {
 	private constructor() {
 		registerDefaultEffects();
 		registerDefaultMasks();
+		registerDefaultTransforms();
+		registerDefaultPresets();
 		this.command = new CommandManager();
 		this.timeline = new TimelineManager(this);
 		this.playback = new PlaybackManager(this);

--- a/apps/web/src/core/managers/timeline-manager.ts
+++ b/apps/web/src/core/managers/timeline-manager.ts
@@ -45,6 +45,14 @@ import {
 	ToggleMaskInvertedCommand,
 	UpsertEffectParamKeyframeCommand,
 	RemoveEffectParamKeyframeCommand,
+	AddClipTransformCommand,
+	ApplyTransformPresetCommand,
+	RemoveClipTransformCommand,
+	UpdateClipTransformParamsCommand,
+	ToggleClipTransformCommand,
+	ReorderClipTransformsCommand,
+	UpsertTransformParamKeyframeCommand,
+	RemoveTransformParamKeyframeCommand,
 } from "@/lib/commands/timeline";
 import { BatchCommand } from "@/lib/commands";
 import type { InsertElementParams } from "@/lib/commands/timeline/element/insert-element";
@@ -441,6 +449,122 @@ export class TimelineManager {
 		this.editor.command.execute({ command });
 	}
 
+	addClipTransform({
+		trackId,
+		elementId,
+		transformType,
+	}: {
+		trackId: string;
+		elementId: string;
+		transformType: string;
+	}): string {
+		const command = new AddClipTransformCommand({
+			trackId,
+			elementId,
+			transformType,
+		});
+		this.editor.command.execute({ command });
+		return command.getTransformId() ?? "";
+	}
+
+	applyTransformPreset({
+		trackId,
+		elementId,
+		presetType,
+	}: {
+		trackId: string;
+		elementId: string;
+		presetType: string;
+	}): string[] {
+		const command = new ApplyTransformPresetCommand({
+			trackId,
+			elementId,
+			presetType,
+		});
+		this.editor.command.execute({ command });
+		return command.getTransformIds();
+	}
+
+	removeClipTransform({
+		trackId,
+		elementId,
+		transformId,
+	}: {
+		trackId: string;
+		elementId: string;
+		transformId: string;
+	}): void {
+		const command = new RemoveClipTransformCommand({
+			trackId,
+			elementId,
+			transformId,
+		});
+		this.editor.command.execute({ command });
+	}
+
+	updateClipTransformParams({
+		trackId,
+		elementId,
+		transformId,
+		params,
+		pushHistory = true,
+	}: {
+		trackId: string;
+		elementId: string;
+		transformId: string;
+		params: Partial<ParamValues>;
+		pushHistory?: boolean;
+	}): void {
+		const command = new UpdateClipTransformParamsCommand({
+			trackId,
+			elementId,
+			transformId,
+			params,
+		});
+		if (pushHistory) {
+			this.editor.command.execute({ command });
+		} else {
+			command.execute();
+		}
+	}
+
+	toggleClipTransform({
+		trackId,
+		elementId,
+		transformId,
+	}: {
+		trackId: string;
+		elementId: string;
+		transformId: string;
+	}): void {
+		const command = new ToggleClipTransformCommand({
+			trackId,
+			elementId,
+			transformId,
+		});
+		this.editor.command.execute({ command });
+	}
+
+	reorderClipTransforms({
+		trackId,
+		elementId,
+		fromIndex,
+		toIndex,
+	}: {
+		trackId: string;
+		elementId: string;
+		fromIndex: number;
+		toIndex: number;
+	}): void {
+		const command = new ReorderClipTransformsCommand({
+			trackId,
+			elementId,
+			fromIndex,
+			toIndex,
+		});
+		this.editor.command.execute({ command });
+	}
+
 	upsertKeyframes({
 		keyframes,
 	}: {
@@ -583,6 +707,61 @@ export class TimelineManager {
 			trackId,
 			elementId,
 			effectId,
+			paramKey,
+			keyframeId,
+		});
+		this.editor.command.execute({ command });
+	}
+
+	upsertTransformParamKeyframe({
+		trackId,
+		elementId,
+		transformId,
+		paramKey,
+		time,
+		value,
+		interpolation,
+		keyframeId,
+	}: {
+		trackId: string;
+		elementId: string;
+		transformId: string;
+		paramKey: string;
+		time: number;
+		value: number;
+		interpolation?: "linear" | "hold";
+		keyframeId?: string;
+	}): void {
+		const command = new UpsertTransformParamKeyframeCommand({
+			trackId,
+			elementId,
+			transformId,
+			paramKey,
+			time,
+			value,
+			interpolation,
+			keyframeId,
+		});
+		this.editor.command.execute({ command });
+	}
+
+	removeTransformParamKeyframe({
+		trackId,
+		elementId,
+		transformId,
+		paramKey,
+		keyframeId,
+	}: {
+		trackId: string;
+		elementId: string;
+		transformId: string;
+		paramKey: string;
+		keyframeId: string;
+	}): void {
+		const command = new RemoveTransformParamKeyframeCommand({
+			trackId,
+			elementId,
+			transformId,
 			paramKey,
 			keyframeId,
 		});

--- a/apps/web/src/lib/animation/index.ts
+++ b/apps/web/src/lib/animation/index.ts
@@ -52,6 +52,28 @@ export {
 } from "./graphic-param-channel";
 
 export {
+	EFFECT_PARAM_PATH_PREFIX,
+	EFFECT_PARAM_PATH_SUFFIX,
+	buildEffectParamPath,
+	isEffectParamPath,
+	parseEffectParamPath,
+	removeEffectParamKeyframe,
+	resolveEffectParamsAtTime,
+	upsertEffectParamKeyframe,
+} from "./effect-param-channel";
+
+export {
+	TRANSFORM_PARAM_PATH_PREFIX,
+	TRANSFORM_PARAM_PATH_SUFFIX,
+	buildTransformParamPath,
+	isTransformParamPath,
+	parseTransformParamPath,
+	removeTransformParamKeyframe,
+	resolveTransformParamsAtTime,
+	upsertTransformParamKeyframe,
+} from "./transform-param-channel";
+
+export {
 	isAnimationPath,
 	resolveAnimationTarget,
 	getParamValueKind,

--- a/apps/web/src/lib/animation/target-resolver.ts
+++ b/apps/web/src/lib/animation/target-resolver.ts
@@ -12,11 +12,19 @@ import {
 	isGraphicParamPath,
 	parseGraphicParamPath,
 } from "@/lib/animation/graphic-param-channel";
+import {
+	isTransformParamPath,
+	parseTransformParamPath,
+} from "@/lib/animation/transform-param-channel";
 import type { ParamDefinition } from "@/lib/params";
 import { effectsRegistry, registerDefaultEffects } from "@/lib/effects";
 import { getGraphicDefinition } from "@/lib/graphics";
+import { transformsRegistry } from "@/lib/transforms/registry";
 import type { TimelineElement } from "@/lib/timeline";
-import { isVisualElement } from "@/lib/timeline/element-utils";
+import {
+	isTransformableElement,
+	isVisualElement,
+} from "@/lib/timeline/element-utils";
 import { snapToStep } from "@/utils/math";
 import {
 	coerceAnimationValueForProperty,
@@ -122,7 +130,9 @@ function buildGraphicParamDescriptor({
 	const definition = getGraphicDefinition({
 		definitionId: element.definitionId,
 	});
-	const param = definition.params.find((candidate) => candidate.key === paramKey);
+	const param = definition.params.find(
+		(candidate) => candidate.key === paramKey,
+	);
 	if (!param) {
 		return null;
 	}
@@ -162,14 +172,18 @@ function buildEffectParamDescriptor({
 		return null;
 	}
 
-	const effect = element.effects?.find((candidate) => candidate.id === effectId);
+	const effect = element.effects?.find(
+		(candidate) => candidate.id === effectId,
+	);
 	if (!effect) {
 		return null;
 	}
 
 	registerDefaultEffects();
 	const definition = effectsRegistry.get(effect.type);
-	const param = definition.params.find((candidate) => candidate.key === paramKey);
+	const param = definition.params.find(
+		(candidate) => candidate.key === paramKey,
+	);
 	if (!param) {
 		return null;
 	}
@@ -204,13 +218,72 @@ function buildEffectParamDescriptor({
 	};
 }
 
+function buildTransformParamDescriptor({
+	element,
+	transformId,
+	paramKey,
+}: {
+	element: TimelineElement;
+	transformId: string;
+	paramKey: string;
+}): AnimationPathDescriptor | null {
+	if (!isTransformableElement(element)) {
+		return null;
+	}
+
+	const transform = element.clipTransforms?.find(
+		(candidate) => candidate.id === transformId,
+	);
+	if (!transform) {
+		return null;
+	}
+
+	const definition = transformsRegistry.get(transform.type);
+	const param = definition.params.find(
+		(candidate) => candidate.key === paramKey,
+	);
+	if (!param) {
+		return null;
+	}
+
+	return {
+		valueKind: getParamValueKind({ param }),
+		defaultInterpolation: getParamDefaultInterpolation({ param }),
+		numericRange: getParamNumericRange({ param }),
+		getBaseValue: () => transform.params[param.key] ?? param.default,
+		setBaseValue: (value) => {
+			const coercedValue = coerceParamValue({ param, value });
+			if (coercedValue === null) {
+				return element;
+			}
+
+			return {
+				...element,
+				clipTransforms:
+					element.clipTransforms?.map((candidate) =>
+						candidate.id !== transformId
+							? candidate
+							: {
+									...candidate,
+									params: {
+										...candidate.params,
+										[param.key]: coercedValue,
+									},
+								},
+					) ?? element.clipTransforms,
+			};
+		},
+	};
+}
+
 export function isAnimationPath(
 	propertyPath: string,
 ): propertyPath is AnimationPath {
 	return (
 		isAnimationPropertyPath(propertyPath) ||
 		isGraphicParamPath(propertyPath) ||
-		isEffectParamPath(propertyPath)
+		isEffectParamPath(propertyPath) ||
+		isTransformParamPath(propertyPath)
 	);
 }
 
@@ -270,6 +343,15 @@ export function resolveAnimationTarget({
 			element,
 			effectId: effectParamTarget.effectId,
 			paramKey: effectParamTarget.paramKey,
+		});
+	}
+
+	const transformParamTarget = parseTransformParamPath({ propertyPath: path });
+	if (transformParamTarget) {
+		return buildTransformParamDescriptor({
+			element,
+			transformId: transformParamTarget.transformId,
+			paramKey: transformParamTarget.paramKey,
 		});
 	}
 

--- a/apps/web/src/lib/animation/transform-param-channel.ts
+++ b/apps/web/src/lib/animation/transform-param-channel.ts
@@ -1,0 +1,157 @@
+import type { ParamValues } from "@/lib/params";
+import type { ClipTransform } from "@/lib/transforms/types";
+import type {
+	ElementAnimations,
+	NumberAnimationChannel,
+	TransformParamPath,
+} from "@/lib/animation/types";
+import {
+	getChannel,
+	removeKeyframe,
+	setChannel,
+	upsertKeyframe,
+} from "./keyframes";
+import { getChannelValueAtTime } from "./interpolation";
+
+export const TRANSFORM_PARAM_PATH_PREFIX = "clipTransforms.";
+export const TRANSFORM_PARAM_PATH_SUFFIX = ".params.";
+
+export function buildTransformParamPath({
+	transformId,
+	paramKey,
+}: {
+	transformId: string;
+	paramKey: string;
+}): TransformParamPath {
+	return `${TRANSFORM_PARAM_PATH_PREFIX}${transformId}${TRANSFORM_PARAM_PATH_SUFFIX}${paramKey}`;
+}
+
+export function isTransformParamPath(
+	propertyPath: string,
+): propertyPath is TransformParamPath {
+	return (
+		propertyPath.startsWith(TRANSFORM_PARAM_PATH_PREFIX) &&
+		propertyPath.includes(TRANSFORM_PARAM_PATH_SUFFIX)
+	);
+}
+
+export function parseTransformParamPath({
+	propertyPath,
+}: {
+	propertyPath: string;
+}): { transformId: string; paramKey: string } | null {
+	if (!isTransformParamPath(propertyPath)) {
+		return null;
+	}
+
+	const withoutPrefix = propertyPath.slice(TRANSFORM_PARAM_PATH_PREFIX.length);
+	const separatorIndex = withoutPrefix.indexOf(TRANSFORM_PARAM_PATH_SUFFIX);
+	if (separatorIndex <= 0) {
+		return null;
+	}
+
+	const transformId = withoutPrefix.slice(0, separatorIndex);
+	const paramKey = withoutPrefix.slice(
+		separatorIndex + TRANSFORM_PARAM_PATH_SUFFIX.length,
+	);
+	if (!transformId || !paramKey) {
+		return null;
+	}
+
+	return { transformId, paramKey };
+}
+
+export function resolveTransformParamsAtTime({
+	transform,
+	animations,
+	localTime,
+}: {
+	transform: ClipTransform;
+	animations: ElementAnimations | undefined;
+	localTime: number;
+}): ParamValues {
+	const resolved: ParamValues = {};
+
+	for (const [paramKey, staticValue] of Object.entries(transform.params)) {
+		const path = buildTransformParamPath({
+			transformId: transform.id,
+			paramKey,
+		});
+		const channel = getChannel({ animations, propertyPath: path });
+		if (channel && channel.keyframes.length > 0) {
+			resolved[paramKey] = getChannelValueAtTime({
+				channel,
+				time: localTime,
+				fallbackValue: staticValue,
+			}) as number | string | boolean;
+		} else {
+			resolved[paramKey] = staticValue;
+		}
+	}
+
+	return resolved;
+}
+
+const EMPTY_NUMBER_CHANNEL: NumberAnimationChannel = {
+	valueKind: "number",
+	keyframes: [],
+};
+
+export function upsertTransformParamKeyframe({
+	animations,
+	transformId,
+	paramKey,
+	time,
+	value,
+	interpolation,
+	keyframeId,
+}: {
+	animations: ElementAnimations | undefined;
+	transformId: string;
+	paramKey: string;
+	time: number;
+	value: number;
+	interpolation?: "linear" | "hold";
+	keyframeId?: string;
+}): ElementAnimations | undefined {
+	const path = buildTransformParamPath({ transformId, paramKey });
+	const channel = getChannel({ animations, propertyPath: path });
+	const targetChannel =
+		channel && channel.valueKind === "number" ? channel : EMPTY_NUMBER_CHANNEL;
+	const updatedChannel = upsertKeyframe({
+		channel: targetChannel,
+		time,
+		value,
+		interpolation: interpolation ?? "linear",
+		keyframeId,
+	});
+
+	return (
+		setChannel({
+			animations,
+			propertyPath: path,
+			channel: updatedChannel,
+		}) ?? { channels: {} }
+	);
+}
+
+export function removeTransformParamKeyframe({
+	animations,
+	transformId,
+	paramKey,
+	keyframeId,
+}: {
+	animations: ElementAnimations | undefined;
+	transformId: string;
+	paramKey: string;
+	keyframeId: string;
+}): ElementAnimations | undefined {
+	const path = buildTransformParamPath({ transformId, paramKey });
+	const channel = getChannel({ animations, propertyPath: path });
+	const updatedChannel = removeKeyframe({ channel, keyframeId });
+	return setChannel({
+		animations,
+		propertyPath: path,
+		channel: updatedChannel,
+	});
+}

--- a/apps/web/src/lib/animation/types.ts
+++ b/apps/web/src/lib/animation/types.ts
@@ -17,10 +17,12 @@ export const ANIMATION_PROPERTY_PATHS = [
 export type AnimationPropertyPath = (typeof ANIMATION_PROPERTY_PATHS)[number];
 export type GraphicParamPath = `params.${string}`;
 export type EffectParamPath = `effects.${string}.params.${string}`;
+export type TransformParamPath = `clipTransforms.${string}.params.${string}`;
 export type AnimationPath =
 	| AnimationPropertyPath
 	| GraphicParamPath
-	| EffectParamPath;
+	| EffectParamPath
+	| TransformParamPath;
 
 export const ANIMATION_PROPERTY_GROUPS = {
 	"transform.scale": ["transform.scaleX", "transform.scaleY"],

--- a/apps/web/src/lib/commands/timeline/element/index.ts
+++ b/apps/web/src/lib/commands/timeline/element/index.ts
@@ -13,3 +13,4 @@ export * from "./keyframes";
 export * from "./effects";
 export * from "./masks";
 export * from "./retime";
+export * from "./transforms";

--- a/apps/web/src/lib/commands/timeline/element/keyframes/index.ts
+++ b/apps/web/src/lib/commands/timeline/element/keyframes/index.ts
@@ -1,5 +1,7 @@
 export * from "./remove-effect-param-keyframe";
 export * from "./remove-keyframe";
+export * from "./remove-transform-param-keyframe";
 export * from "./retime-keyframe";
 export * from "./upsert-effect-param-keyframe";
 export * from "./upsert-keyframe";
+export * from "./upsert-transform-param-keyframe";

--- a/apps/web/src/lib/commands/timeline/element/keyframes/remove-transform-param-keyframe.ts
+++ b/apps/web/src/lib/commands/timeline/element/keyframes/remove-transform-param-keyframe.ts
@@ -1,0 +1,68 @@
+import { EditorCore } from "@/core";
+import { Command } from "@/lib/commands/base-command";
+import { removeTransformParamKeyframe } from "@/lib/animation/transform-param-channel";
+import { updateElementInTracks } from "@/lib/timeline";
+import { isTransformableElement } from "@/lib/timeline/element-utils";
+import type { TimelineTrack } from "@/lib/timeline";
+
+export class RemoveTransformParamKeyframeCommand extends Command {
+	private savedState: TimelineTrack[] | null = null;
+	private readonly trackId: string;
+	private readonly elementId: string;
+	private readonly transformId: string;
+	private readonly paramKey: string;
+	private readonly keyframeId: string;
+
+	constructor({
+		trackId,
+		elementId,
+		transformId,
+		paramKey,
+		keyframeId,
+	}: {
+		trackId: string;
+		elementId: string;
+		transformId: string;
+		paramKey: string;
+		keyframeId: string;
+	}) {
+		super();
+		this.trackId = trackId;
+		this.elementId = elementId;
+		this.transformId = transformId;
+		this.paramKey = paramKey;
+		this.keyframeId = keyframeId;
+	}
+
+	execute(): void {
+		const editor = EditorCore.getInstance();
+		this.savedState = editor.timeline.getTracks();
+
+		const updatedTracks = updateElementInTracks({
+			tracks: this.savedState,
+			trackId: this.trackId,
+			elementId: this.elementId,
+			elementPredicate: isTransformableElement,
+			update: (element) => {
+				const animations = removeTransformParamKeyframe({
+					animations: element.animations,
+					transformId: this.transformId,
+					paramKey: this.paramKey,
+					keyframeId: this.keyframeId,
+				});
+				return { ...element, animations };
+			},
+		});
+
+		editor.timeline.updateTracks(updatedTracks);
+	}
+
+	undo(): void {
+		if (!this.savedState) {
+			return;
+		}
+
+		const editor = EditorCore.getInstance();
+		editor.timeline.updateTracks(this.savedState);
+	}
+}

--- a/apps/web/src/lib/commands/timeline/element/keyframes/upsert-transform-param-keyframe.ts
+++ b/apps/web/src/lib/commands/timeline/element/keyframes/upsert-transform-param-keyframe.ts
@@ -1,0 +1,84 @@
+import { EditorCore } from "@/core";
+import { Command } from "@/lib/commands/base-command";
+import { upsertTransformParamKeyframe } from "@/lib/animation/transform-param-channel";
+import { updateElementInTracks } from "@/lib/timeline";
+import { isTransformableElement } from "@/lib/timeline/element-utils";
+import type { TimelineTrack } from "@/lib/timeline";
+
+export class UpsertTransformParamKeyframeCommand extends Command {
+	private savedState: TimelineTrack[] | null = null;
+	private readonly trackId: string;
+	private readonly elementId: string;
+	private readonly transformId: string;
+	private readonly paramKey: string;
+	private readonly time: number;
+	private readonly value: number;
+	private readonly interpolation: "linear" | "hold" | undefined;
+	private readonly keyframeId: string | undefined;
+
+	constructor({
+		trackId,
+		elementId,
+		transformId,
+		paramKey,
+		time,
+		value,
+		interpolation,
+		keyframeId,
+	}: {
+		trackId: string;
+		elementId: string;
+		transformId: string;
+		paramKey: string;
+		time: number;
+		value: number;
+		interpolation?: "linear" | "hold";
+		keyframeId?: string;
+	}) {
+		super();
+		this.trackId = trackId;
+		this.elementId = elementId;
+		this.transformId = transformId;
+		this.paramKey = paramKey;
+		this.time = time;
+		this.value = value;
+		this.interpolation = interpolation;
+		this.keyframeId = keyframeId;
+	}
+
+	execute(): void {
+		const editor = EditorCore.getInstance();
+		this.savedState = editor.timeline.getTracks();
+
+		const updatedTracks = updateElementInTracks({
+			tracks: this.savedState,
+			trackId: this.trackId,
+			elementId: this.elementId,
+			elementPredicate: isTransformableElement,
+			update: (element) => {
+				const boundedTime = Math.max(0, Math.min(this.time, element.duration));
+				const animations = upsertTransformParamKeyframe({
+					animations: element.animations,
+					transformId: this.transformId,
+					paramKey: this.paramKey,
+					time: boundedTime,
+					value: this.value,
+					interpolation: this.interpolation,
+					keyframeId: this.keyframeId,
+				});
+				return { ...element, animations };
+			},
+		});
+
+		editor.timeline.updateTracks(updatedTracks);
+	}
+
+	undo(): void {
+		if (!this.savedState) {
+			return;
+		}
+
+		const editor = EditorCore.getInstance();
+		editor.timeline.updateTracks(this.savedState);
+	}
+}

--- a/apps/web/src/lib/commands/timeline/element/transforms/add-transform.ts
+++ b/apps/web/src/lib/commands/timeline/element/transforms/add-transform.ts
@@ -1,0 +1,74 @@
+import { Command } from "@/lib/commands/base-command";
+import { EditorCore } from "@/core";
+import { isTransformableElement, updateElementInTracks } from "@/lib/timeline";
+import type { TimelineTrack, TransformableElement } from "@/lib/timeline";
+import { buildDefaultTransformInstance } from "@/lib/transforms";
+
+function addTransformToElement({
+	element,
+	transformType,
+}: {
+	element: TransformableElement;
+	transformType: string;
+}): TransformableElement {
+	const instance = buildDefaultTransformInstance({ transformType });
+	const currentTransforms = element.clipTransforms ?? [];
+	return { ...element, clipTransforms: [...currentTransforms, instance] };
+}
+
+export class AddClipTransformCommand extends Command {
+	private savedState: TimelineTrack[] | null = null;
+	private transformId: string | null = null;
+	private readonly trackId: string;
+	private readonly elementId: string;
+	private readonly transformType: string;
+
+	constructor({
+		trackId,
+		elementId,
+		transformType,
+	}: {
+		trackId: string;
+		elementId: string;
+		transformType: string;
+	}) {
+		super();
+		this.trackId = trackId;
+		this.elementId = elementId;
+		this.transformType = transformType;
+	}
+
+	execute(): void {
+		const editor = EditorCore.getInstance();
+		this.savedState = editor.timeline.getTracks();
+
+		const updatedTracks = updateElementInTracks({
+			tracks: this.savedState,
+			trackId: this.trackId,
+			elementId: this.elementId,
+			elementPredicate: isTransformableElement,
+			update: (element) => {
+				const updated = addTransformToElement({
+					element: element as TransformableElement,
+					transformType: this.transformType,
+				});
+				const transforms = updated.clipTransforms ?? [];
+				this.transformId = transforms[transforms.length - 1]?.id ?? null;
+				return updated;
+			},
+		});
+
+		editor.timeline.updateTracks(updatedTracks);
+	}
+
+	undo(): void {
+		if (this.savedState) {
+			const editor = EditorCore.getInstance();
+			editor.timeline.updateTracks(this.savedState);
+		}
+	}
+
+	getTransformId(): string | null {
+		return this.transformId;
+	}
+}

--- a/apps/web/src/lib/commands/timeline/element/transforms/apply-preset-to-element.ts
+++ b/apps/web/src/lib/commands/timeline/element/transforms/apply-preset-to-element.ts
@@ -1,0 +1,135 @@
+import type { TransformableElement } from "@/lib/timeline";
+import { buildDefaultParamValues } from "@/lib/registry";
+import { transformsRegistry } from "@/lib/transforms/registry";
+import { getPreset } from "@/lib/transforms/presets/registry";
+import type { TransformPresetKeyframe } from "@/lib/transforms/presets/types";
+import type { ClipTransform } from "@/lib/transforms/types";
+import { buildTransformParamPath } from "@/lib/animation/transform-param-channel";
+import {
+	upsertKeyframe,
+	setChannel,
+	getChannel,
+} from "@/lib/animation/keyframes";
+import type {
+	ElementAnimations,
+	NumberAnimationChannel,
+} from "@/lib/animation/types";
+import { generateUUID } from "@/utils/id";
+
+const EMPTY_NUMBER_CHANNEL: NumberAnimationChannel = {
+	valueKind: "number",
+	keyframes: [],
+};
+
+/**
+ * Converts one preset param's normalized (0..1) keyframes into an
+ * animation channel written at `clipTransforms.<transformId>.params.<key>`,
+ * mapping normalized time -> absolute seconds via the target clip's
+ * duration. Mirrors `upsertTransformParamKeyframe` but builds a whole
+ * channel in one pass instead of one keyframe at a time, since a preset
+ * always supplies its full keyframe list up front.
+ */
+export function applyKeyframesToChannel({
+	animations,
+	transformId,
+	paramKey,
+	keyframes,
+	clipDuration,
+}: {
+	animations: ElementAnimations | undefined;
+	transformId: string;
+	paramKey: string;
+	keyframes: TransformPresetKeyframe[];
+	clipDuration: number;
+}): ElementAnimations | undefined {
+	const path = buildTransformParamPath({ transformId, paramKey });
+	const channel = getChannel({ animations, propertyPath: path });
+	let targetChannel =
+		channel && channel.valueKind === "number" ? channel : EMPTY_NUMBER_CHANNEL;
+
+	for (const keyframe of keyframes) {
+		// Preset easing (e.g. "ease-out-cubic") has no bezier equivalent in
+		// dev's animation system — only "linear" | "hold" interpolation is
+		// supported, so every preset keyframe is written as "linear".
+		const boundedTime = Math.max(
+			0,
+			Math.min(keyframe.normalizedTime * clipDuration, clipDuration),
+		);
+		const updated = upsertKeyframe({
+			channel: targetChannel,
+			time: boundedTime,
+			value: keyframe.value,
+			interpolation: "linear",
+			keyframeId: generateUUID(),
+		});
+		if (updated && updated.valueKind === "number") {
+			targetChannel = updated;
+		}
+	}
+
+	return (
+		setChannel({
+			animations,
+			propertyPath: path,
+			channel: targetChannel,
+		}) ?? { channels: {} }
+	);
+}
+
+/**
+ * Pure preset-application logic, extracted from `ApplyTransformPresetCommand`
+ * so it can be unit tested without going through `EditorCore`/command
+ * execution. Builds new `ClipTransform` instances for each preset entry
+ * (default params merged with preset static params) and writes animation
+ * channels for any keyframed params.
+ */
+export function applyPresetToElement({
+	element,
+	presetType,
+}: {
+	element: TransformableElement;
+	presetType: string;
+}): { element: TransformableElement; transformIds: string[] } {
+	const preset = getPreset(presetType);
+	const clipDuration = element.duration;
+
+	let animations = element.animations;
+	const newTransforms: ClipTransform[] = [];
+	const transformIds: string[] = [];
+
+	for (const entry of preset.transforms) {
+		const definition = transformsRegistry.get(entry.transformType);
+		const defaultParams = buildDefaultParamValues(definition.params);
+		const transformId = generateUUID();
+		transformIds.push(transformId);
+
+		newTransforms.push({
+			id: transformId,
+			type: entry.transformType,
+			params: { ...defaultParams, ...entry.params },
+			enabled: true,
+		});
+
+		for (const [paramKey, keyframes] of Object.entries(
+			entry.animatedParams ?? {},
+		)) {
+			animations = applyKeyframesToChannel({
+				animations,
+				transformId,
+				paramKey,
+				keyframes,
+				clipDuration,
+			});
+		}
+	}
+
+	const currentTransforms = element.clipTransforms ?? [];
+	return {
+		element: {
+			...element,
+			clipTransforms: [...currentTransforms, ...newTransforms],
+			animations,
+		},
+		transformIds,
+	};
+}

--- a/apps/web/src/lib/commands/timeline/element/transforms/apply-preset.ts
+++ b/apps/web/src/lib/commands/timeline/element/transforms/apply-preset.ts
@@ -1,0 +1,61 @@
+import { Command } from "@/lib/commands/base-command";
+import { EditorCore } from "@/core";
+import { isTransformableElement, updateElementInTracks } from "@/lib/timeline";
+import type { TimelineTrack, TransformableElement } from "@/lib/timeline";
+import { applyPresetToElement } from "./apply-preset-to-element";
+
+export class ApplyTransformPresetCommand extends Command {
+	private savedState: TimelineTrack[] | null = null;
+	private transformIds: string[] = [];
+	private readonly trackId: string;
+	private readonly elementId: string;
+	private readonly presetType: string;
+
+	constructor({
+		trackId,
+		elementId,
+		presetType,
+	}: {
+		trackId: string;
+		elementId: string;
+		presetType: string;
+	}) {
+		super();
+		this.trackId = trackId;
+		this.elementId = elementId;
+		this.presetType = presetType;
+	}
+
+	execute(): void {
+		const editor = EditorCore.getInstance();
+		this.savedState = editor.timeline.getTracks();
+
+		const updatedTracks = updateElementInTracks({
+			tracks: this.savedState,
+			trackId: this.trackId,
+			elementId: this.elementId,
+			elementPredicate: isTransformableElement,
+			update: (element) => {
+				const result = applyPresetToElement({
+					element: element as TransformableElement,
+					presetType: this.presetType,
+				});
+				this.transformIds = result.transformIds;
+				return result.element;
+			},
+		});
+
+		editor.timeline.updateTracks(updatedTracks);
+	}
+
+	undo(): void {
+		if (this.savedState) {
+			const editor = EditorCore.getInstance();
+			editor.timeline.updateTracks(this.savedState);
+		}
+	}
+
+	getTransformIds(): string[] {
+		return this.transformIds;
+	}
+}

--- a/apps/web/src/lib/commands/timeline/element/transforms/index.ts
+++ b/apps/web/src/lib/commands/timeline/element/transforms/index.ts
@@ -1,0 +1,6 @@
+export { AddClipTransformCommand } from "./add-transform";
+export { ApplyTransformPresetCommand } from "./apply-preset";
+export { RemoveClipTransformCommand } from "./remove-transform";
+export { ToggleClipTransformCommand } from "./toggle-transform";
+export { UpdateClipTransformParamsCommand } from "./update-transform-params";
+export { ReorderClipTransformsCommand } from "./reorder-transform";

--- a/apps/web/src/lib/commands/timeline/element/transforms/remove-transform.ts
+++ b/apps/web/src/lib/commands/timeline/element/transforms/remove-transform.ts
@@ -1,0 +1,66 @@
+import { Command } from "@/lib/commands/base-command";
+import { EditorCore } from "@/core";
+import { isTransformableElement, updateElementInTracks } from "@/lib/timeline";
+import type { TimelineTrack, TransformableElement } from "@/lib/timeline";
+
+function removeTransformFromElement({
+	element,
+	transformId,
+}: {
+	element: TransformableElement;
+	transformId: string;
+}): TransformableElement {
+	const currentTransforms = element.clipTransforms ?? [];
+	const filtered = currentTransforms.filter(
+		(transform) => transform.id !== transformId,
+	);
+	return { ...element, clipTransforms: filtered };
+}
+
+export class RemoveClipTransformCommand extends Command {
+	private savedState: TimelineTrack[] | null = null;
+	private readonly trackId: string;
+	private readonly elementId: string;
+	private readonly transformId: string;
+
+	constructor({
+		trackId,
+		elementId,
+		transformId,
+	}: {
+		trackId: string;
+		elementId: string;
+		transformId: string;
+	}) {
+		super();
+		this.trackId = trackId;
+		this.elementId = elementId;
+		this.transformId = transformId;
+	}
+
+	execute(): void {
+		const editor = EditorCore.getInstance();
+		this.savedState = editor.timeline.getTracks();
+
+		const updatedTracks = updateElementInTracks({
+			tracks: this.savedState,
+			trackId: this.trackId,
+			elementId: this.elementId,
+			elementPredicate: isTransformableElement,
+			update: (element) =>
+				removeTransformFromElement({
+					element: element as TransformableElement,
+					transformId: this.transformId,
+				}),
+		});
+
+		editor.timeline.updateTracks(updatedTracks);
+	}
+
+	undo(): void {
+		if (this.savedState) {
+			const editor = EditorCore.getInstance();
+			editor.timeline.updateTracks(this.savedState);
+		}
+	}
+}

--- a/apps/web/src/lib/commands/timeline/element/transforms/reorder-transform.ts
+++ b/apps/web/src/lib/commands/timeline/element/transforms/reorder-transform.ts
@@ -1,0 +1,72 @@
+import { Command } from "@/lib/commands/base-command";
+import { EditorCore } from "@/core";
+import { isTransformableElement, updateElementInTracks } from "@/lib/timeline";
+import type { TimelineTrack, TransformableElement } from "@/lib/timeline";
+
+function reorderTransformsOnElement({
+	element,
+	fromIndex,
+	toIndex,
+}: {
+	element: TransformableElement;
+	fromIndex: number;
+	toIndex: number;
+}): TransformableElement {
+	const transforms = [...(element.clipTransforms ?? [])];
+	const [moved] = transforms.splice(fromIndex, 1);
+	transforms.splice(toIndex, 0, moved);
+	return { ...element, clipTransforms: transforms };
+}
+
+export class ReorderClipTransformsCommand extends Command {
+	private savedState: TimelineTrack[] | null = null;
+	private readonly trackId: string;
+	private readonly elementId: string;
+	private readonly fromIndex: number;
+	private readonly toIndex: number;
+
+	constructor({
+		trackId,
+		elementId,
+		fromIndex,
+		toIndex,
+	}: {
+		trackId: string;
+		elementId: string;
+		fromIndex: number;
+		toIndex: number;
+	}) {
+		super();
+		this.trackId = trackId;
+		this.elementId = elementId;
+		this.fromIndex = fromIndex;
+		this.toIndex = toIndex;
+	}
+
+	execute(): void {
+		const editor = EditorCore.getInstance();
+		this.savedState = editor.timeline.getTracks();
+
+		const updatedTracks = updateElementInTracks({
+			tracks: this.savedState,
+			trackId: this.trackId,
+			elementId: this.elementId,
+			elementPredicate: isTransformableElement,
+			update: (element) =>
+				reorderTransformsOnElement({
+					element: element as TransformableElement,
+					fromIndex: this.fromIndex,
+					toIndex: this.toIndex,
+				}),
+		});
+
+		editor.timeline.updateTracks(updatedTracks);
+	}
+
+	undo(): void {
+		if (this.savedState) {
+			const editor = EditorCore.getInstance();
+			editor.timeline.updateTracks(this.savedState);
+		}
+	}
+}

--- a/apps/web/src/lib/commands/timeline/element/transforms/toggle-transform.ts
+++ b/apps/web/src/lib/commands/timeline/element/transforms/toggle-transform.ts
@@ -1,0 +1,68 @@
+import { Command } from "@/lib/commands/base-command";
+import { EditorCore } from "@/core";
+import { isTransformableElement, updateElementInTracks } from "@/lib/timeline";
+import type { TimelineTrack, TransformableElement } from "@/lib/timeline";
+
+export function toggleTransformOnElement({
+	element,
+	transformId,
+}: {
+	element: TransformableElement;
+	transformId: string;
+}): TransformableElement {
+	const currentTransforms = element.clipTransforms ?? [];
+	const updated = currentTransforms.map((transform) =>
+		transform.id === transformId
+			? { ...transform, enabled: !transform.enabled }
+			: transform,
+	);
+	return { ...element, clipTransforms: updated };
+}
+
+export class ToggleClipTransformCommand extends Command {
+	private savedState: TimelineTrack[] | null = null;
+	private readonly trackId: string;
+	private readonly elementId: string;
+	private readonly transformId: string;
+
+	constructor({
+		trackId,
+		elementId,
+		transformId,
+	}: {
+		trackId: string;
+		elementId: string;
+		transformId: string;
+	}) {
+		super();
+		this.trackId = trackId;
+		this.elementId = elementId;
+		this.transformId = transformId;
+	}
+
+	execute(): void {
+		const editor = EditorCore.getInstance();
+		this.savedState = editor.timeline.getTracks();
+
+		const updatedTracks = updateElementInTracks({
+			tracks: this.savedState,
+			trackId: this.trackId,
+			elementId: this.elementId,
+			elementPredicate: isTransformableElement,
+			update: (element) =>
+				toggleTransformOnElement({
+					element: element as TransformableElement,
+					transformId: this.transformId,
+				}),
+		});
+
+		editor.timeline.updateTracks(updatedTracks);
+	}
+
+	undo(): void {
+		if (this.savedState) {
+			const editor = EditorCore.getInstance();
+			editor.timeline.updateTracks(this.savedState);
+		}
+	}
+}

--- a/apps/web/src/lib/commands/timeline/element/transforms/update-transform-params.ts
+++ b/apps/web/src/lib/commands/timeline/element/transforms/update-transform-params.ts
@@ -1,0 +1,85 @@
+import { Command } from "@/lib/commands/base-command";
+import { EditorCore } from "@/core";
+import { isTransformableElement, updateElementInTracks } from "@/lib/timeline";
+import type { ParamValues } from "@/lib/params";
+import type { TimelineTrack, TransformableElement } from "@/lib/timeline";
+
+function updateTransformParamsOnElement({
+	element,
+	transformId,
+	params,
+}: {
+	element: TransformableElement;
+	transformId: string;
+	params: Partial<ParamValues>;
+}): TransformableElement {
+	const currentTransforms = element.clipTransforms ?? [];
+	const updated = currentTransforms.map((transform) => {
+		if (transform.id !== transformId) {
+			return transform;
+		}
+
+		const nextParams = { ...transform.params };
+		for (const [key, value] of Object.entries(params)) {
+			if (value !== undefined) {
+				nextParams[key] = value;
+			}
+		}
+
+		return { ...transform, params: nextParams };
+	});
+	return { ...element, clipTransforms: updated };
+}
+
+export class UpdateClipTransformParamsCommand extends Command {
+	private savedState: TimelineTrack[] | null = null;
+	private readonly trackId: string;
+	private readonly elementId: string;
+	private readonly transformId: string;
+	private readonly params: Partial<ParamValues>;
+
+	constructor({
+		trackId,
+		elementId,
+		transformId,
+		params,
+	}: {
+		trackId: string;
+		elementId: string;
+		transformId: string;
+		params: Partial<ParamValues>;
+	}) {
+		super();
+		this.trackId = trackId;
+		this.elementId = elementId;
+		this.transformId = transformId;
+		this.params = params;
+	}
+
+	execute(): void {
+		const editor = EditorCore.getInstance();
+		this.savedState = editor.timeline.getTracks();
+
+		const updatedTracks = updateElementInTracks({
+			tracks: this.savedState,
+			trackId: this.trackId,
+			elementId: this.elementId,
+			elementPredicate: isTransformableElement,
+			update: (element) =>
+				updateTransformParamsOnElement({
+					element: element as TransformableElement,
+					transformId: this.transformId,
+					params: this.params,
+				}),
+		});
+
+		editor.timeline.updateTracks(updatedTracks);
+	}
+
+	undo(): void {
+		if (this.savedState) {
+			const editor = EditorCore.getInstance();
+			editor.timeline.updateTracks(this.savedState);
+		}
+	}
+}

--- a/apps/web/src/lib/effects/categories.ts
+++ b/apps/web/src/lib/effects/categories.ts
@@ -1,0 +1,31 @@
+/** Effect categories for UI grouping */
+export const EffectCategory = {
+	COLOR_TONE: "color-tone",
+	ARTISTIC: "artistic",
+	BEAUTY: "beauty",
+} as const;
+
+export type EffectCategory =
+	(typeof EffectCategory)[keyof typeof EffectCategory];
+
+export interface EffectCategoryMeta {
+	label: string;
+	description: string;
+}
+
+/** Display metadata for each effect category */
+export const EFFECT_CATEGORY_META: Record<EffectCategory, EffectCategoryMeta> =
+	{
+		[EffectCategory.COLOR_TONE]: {
+			label: "Color & Tone",
+			description: "Brightness, contrast, saturation, and color adjustments",
+		},
+		[EffectCategory.ARTISTIC]: {
+			label: "Artistic",
+			description: "Stylize effects like blur, vignette, and film grain",
+		},
+		[EffectCategory.BEAUTY]: {
+			label: "Beauty",
+			description: "Face-aware beauty effects using AI detection",
+		},
+	};

--- a/apps/web/src/lib/effects/common.glsl
+++ b/apps/web/src/lib/effects/common.glsl
@@ -1,0 +1,43 @@
+// Shared GLSL utility functions for color effects
+// NOTE: WebGL 1 has no #include — copy relevant functions into each shader
+
+// --- Luminance ---
+// float luminance(vec3 color) {
+//   return dot(color, vec3(0.2126, 0.7152, 0.0722));
+// }
+
+// --- RGB to HSL ---
+// vec3 rgb2hsl(vec3 c) {
+//   float maxC = max(c.r, max(c.g, c.b));
+//   float minC = min(c.r, min(c.g, c.b));
+//   float l = (maxC + minC) * 0.5;
+//   if (maxC == minC) return vec3(0.0, 0.0, l);
+//   float d = maxC - minC;
+//   float s = l > 0.5 ? d / (2.0 - maxC - minC) : d / (maxC + minC);
+//   float h;
+//   if (maxC == c.r) h = (c.g - c.b) / d + (c.g < c.b ? 6.0 : 0.0);
+//   else if (maxC == c.g) h = (c.b - c.r) / d + 2.0;
+//   else h = (c.r - c.g) / d + 4.0;
+//   h /= 6.0;
+//   return vec3(h, s, l);
+// }
+
+// --- HSL to RGB ---
+// float hue2rgb(float p, float q, float t) {
+//   if (t < 0.0) t += 1.0;
+//   if (t > 1.0) t -= 1.0;
+//   if (t < 1.0/6.0) return p + (q - p) * 6.0 * t;
+//   if (t < 1.0/2.0) return q;
+//   if (t < 2.0/3.0) return p + (q - p) * (2.0/3.0 - t) * 6.0;
+//   return p;
+// }
+// vec3 hsl2rgb(vec3 hsl) {
+//   if (hsl.y == 0.0) return vec3(hsl.z);
+//   float q = hsl.z < 0.5 ? hsl.z * (1.0 + hsl.y) : hsl.z + hsl.y - hsl.z * hsl.y;
+//   float p = 2.0 * hsl.z - q;
+//   return vec3(
+//     hue2rgb(p, q, hsl.x + 1.0/3.0),
+//     hue2rgb(p, q, hsl.x),
+//     hue2rgb(p, q, hsl.x - 1.0/3.0)
+//   );
+// }

--- a/apps/web/src/lib/effects/definitions/blush/blush.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/blush/blush.frag.glsl
@@ -1,0 +1,26 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_intensity;
+uniform vec3 u_color;
+uniform vec2 u_cheekLeft;
+uniform vec2 u_cheekRight;
+uniform float u_cheekRadius;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+
+  // Soft circle blend at cheek positions
+  float distL = distance(v_texCoord, u_cheekLeft);
+  float distR = distance(v_texCoord, u_cheekRight);
+  float maskL = 1.0 - smoothstep(u_cheekRadius * 0.6, u_cheekRadius, distL);
+  float maskR = 1.0 - smoothstep(u_cheekRadius * 0.6, u_cheekRadius, distR);
+  float mask = max(maskL, maskR) * u_intensity;
+
+  // Soft light blend with blush color
+  color.rgb = mix(color.rgb, color.rgb * u_color + u_color * 0.2, mask);
+  gl_FragColor = vec4(clamp(color.rgb, 0.0, 1.0), color.a);
+}

--- a/apps/web/src/lib/effects/definitions/blush/index.ts
+++ b/apps/web/src/lib/effects/definitions/blush/index.ts
@@ -1,0 +1,40 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { hexToRgb } from "@/lib/effects/utils/color";
+import { getNumberParam, getStringParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./blush.frag.glsl";
+
+/** Blush — soft color blend at cheek positions from face landmarks */
+export const blushEffectDefinition: EffectDefinition = {
+	type: "blush",
+	name: "Blush",
+	category: EffectCategory.BEAUTY,
+	keywords: ["blush", "cheeks", "rosy", "beauty", "makeup"],
+	params: [
+		{
+			key: "intensity",
+			label: "Intensity",
+			type: "number",
+			default: 30,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+		{ key: "color", label: "Color", type: "color", default: "#ff9999" },
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams, context }) => ({
+					u_intensity: getNumberParam(effectParams, "intensity") / 100,
+					u_color: hexToRgb(getStringParam(effectParams, "color", "#ff9999")),
+					u_cheekLeft: context?.cheekLeft ?? [0.35, 0.55],
+					u_cheekRight: context?.cheekRight ?? [0.65, 0.55],
+					u_cheekRadius: context?.cheekRadius ?? 0.08,
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/brightness/brightness.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/brightness/brightness.frag.glsl
@@ -1,0 +1,13 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_intensity;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  color.rgb += u_intensity;
+  gl_FragColor = vec4(clamp(color.rgb, 0.0, 1.0), color.a);
+}

--- a/apps/web/src/lib/effects/definitions/brightness/index.ts
+++ b/apps/web/src/lib/effects/definitions/brightness/index.ts
@@ -1,0 +1,33 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./brightness.frag.glsl";
+
+export const brightnessEffectDefinition: EffectDefinition = {
+	type: "brightness",
+	name: "Brightness",
+	category: EffectCategory.COLOR_TONE,
+	keywords: ["brightness", "light", "dark", "brighten", "darken"],
+	params: [
+		{
+			key: "intensity",
+			label: "Intensity",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams }) => ({
+					u_intensity: getNumberParam(effectParams, "intensity") / 100,
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/chromatic-aberration/chromatic-aberration.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/chromatic-aberration/chromatic-aberration.frag.glsl
@@ -1,0 +1,21 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_intensity;
+uniform float u_angle;
+
+varying vec2 v_texCoord;
+
+void main() {
+  // Offset direction based on angle
+  vec2 dir = vec2(cos(u_angle), sin(u_angle)) * u_intensity;
+  vec2 texel = dir / u_resolution;
+
+  float r = texture2D(u_texture, v_texCoord + texel).r;
+  float g = texture2D(u_texture, v_texCoord).g;
+  float b = texture2D(u_texture, v_texCoord - texel).b;
+  float a = texture2D(u_texture, v_texCoord).a;
+
+  gl_FragColor = vec4(r, g, b, a);
+}

--- a/apps/web/src/lib/effects/definitions/chromatic-aberration/chromatic-aberration.test.ts
+++ b/apps/web/src/lib/effects/definitions/chromatic-aberration/chromatic-aberration.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect } from "bun:test";
+import { chromaticAberrationEffectDefinition } from "./index";
+import { EffectCategory } from "@/lib/effects/categories";
+
+describe("Chromatic Aberration Effect Definition", () => {
+	test("has correct type and name", () => {
+		expect(chromaticAberrationEffectDefinition.type).toBe(
+			"chromatic-aberration",
+		);
+		expect(chromaticAberrationEffectDefinition.name).toBe(
+			"Chromatic Aberration",
+		);
+	});
+
+	test("is categorized as artistic", () => {
+		expect(chromaticAberrationEffectDefinition.category).toBe(
+			EffectCategory.ARTISTIC,
+		);
+	});
+
+	test("has searchable keywords", () => {
+		expect(chromaticAberrationEffectDefinition.keywords).toContain("chromatic");
+		expect(chromaticAberrationEffectDefinition.keywords).toContain(
+			"aberration",
+		);
+		expect(chromaticAberrationEffectDefinition.keywords).toContain("rgb split");
+		expect(chromaticAberrationEffectDefinition.keywords).toContain("prism");
+	});
+
+	test("has 2 params: intensity and angle", () => {
+		expect(
+			chromaticAberrationEffectDefinition.params.map((p) => p.key),
+		).toEqual(["intensity", "angle"]);
+	});
+
+	test("intensity param has correct defaults", () => {
+		const param = chromaticAberrationEffectDefinition.params[0];
+		expect(param.key).toBe("intensity");
+		expect(param.type).toBe("number");
+		if (param.type === "number") {
+			expect(param.default).toBe(20);
+			expect(param.min).toBe(0);
+			expect(param.max).toBe(100);
+			expect(param.step).toBe(1);
+		}
+	});
+
+	test("angle param has correct defaults", () => {
+		const param = chromaticAberrationEffectDefinition.params[1];
+		expect(param.key).toBe("angle");
+		expect(param.type).toBe("number");
+		if (param.type === "number") {
+			expect(param.default).toBe(0);
+			expect(param.min).toBe(0);
+			expect(param.max).toBe(360);
+			expect(param.step).toBe(1);
+		}
+	});
+
+	test("renderer has single pass", () => {
+		expect(chromaticAberrationEffectDefinition.renderer.type).toBe("webgl");
+		expect(chromaticAberrationEffectDefinition.renderer.passes).toHaveLength(1);
+	});
+
+	test("uniforms scale intensity by factor of 10", () => {
+		const pass = chromaticAberrationEffectDefinition.renderer.passes[0];
+		const at0 = pass.uniforms({
+			effectParams: { intensity: 0, angle: 0 },
+			width: 1920,
+			height: 1080,
+		});
+		const at100 = pass.uniforms({
+			effectParams: { intensity: 100, angle: 0 },
+			width: 1920,
+			height: 1080,
+		});
+		expect(at0.u_intensity).toBe(0);
+		expect(at100.u_intensity).toBe(10); // 100 / 10 = 10
+	});
+
+	test("uniforms convert angle from degrees to radians", () => {
+		const pass = chromaticAberrationEffectDefinition.renderer.passes[0];
+		const at0 = pass.uniforms({
+			effectParams: { intensity: 50, angle: 0 },
+			width: 1920,
+			height: 1080,
+		});
+		const at90 = pass.uniforms({
+			effectParams: { intensity: 50, angle: 90 },
+			width: 1920,
+			height: 1080,
+		});
+		const at180 = pass.uniforms({
+			effectParams: { intensity: 50, angle: 180 },
+			width: 1920,
+			height: 1080,
+		});
+		const at360 = pass.uniforms({
+			effectParams: { intensity: 50, angle: 360 },
+			width: 1920,
+			height: 1080,
+		});
+		expect(at0.u_angle).toBe(0);
+		expect(at90.u_angle).toBeCloseTo(Math.PI / 2, 5);
+		expect(at180.u_angle).toBeCloseTo(Math.PI, 5);
+		expect(at360.u_angle).toBeCloseTo(2 * Math.PI, 5);
+	});
+
+	test("angle 45 degrees converts correctly", () => {
+		const pass = chromaticAberrationEffectDefinition.renderer.passes[0];
+		const result = pass.uniforms({
+			effectParams: { intensity: 50, angle: 45 },
+			width: 1920,
+			height: 1080,
+		});
+		expect(result.u_angle).toBeCloseTo(Math.PI / 4, 5);
+	});
+
+	test("uniforms with default values", () => {
+		const pass = chromaticAberrationEffectDefinition.renderer.passes[0];
+		const result = pass.uniforms({
+			effectParams: { intensity: 20, angle: 0 },
+			width: 1920,
+			height: 1080,
+		});
+		expect(result.u_intensity).toBe(2); // 20 / 10 = 2
+		expect(result.u_angle).toBe(0);
+	});
+});

--- a/apps/web/src/lib/effects/definitions/chromatic-aberration/index.ts
+++ b/apps/web/src/lib/effects/definitions/chromatic-aberration/index.ts
@@ -1,0 +1,50 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./chromatic-aberration.frag.glsl";
+
+export const chromaticAberrationEffectDefinition: EffectDefinition = {
+	type: "chromatic-aberration",
+	name: "Chromatic Aberration",
+	category: EffectCategory.ARTISTIC,
+	keywords: [
+		"chromatic",
+		"aberration",
+		"rgb split",
+		"lens",
+		"distortion",
+		"prism",
+	],
+	params: [
+		{
+			key: "intensity",
+			label: "Intensity",
+			type: "number",
+			default: 20,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "angle",
+			label: "Angle",
+			type: "number",
+			default: 0,
+			min: 0,
+			max: 360,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams }) => ({
+					u_intensity: getNumberParam(effectParams, "intensity") / 10,
+					u_angle: (getNumberParam(effectParams, "angle") * Math.PI) / 180,
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/color-balance/color-balance.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/color-balance/color-balance.frag.glsl
@@ -1,0 +1,26 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform vec3 u_shadows;
+uniform vec3 u_midtones;
+uniform vec3 u_highlights;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  float luma = dot(color.rgb, vec3(0.2126, 0.7152, 0.0722));
+
+  // Weight regions by luminance
+  float shadowWeight = 1.0 - smoothstep(0.0, 0.5, luma);
+  float highlightWeight = smoothstep(0.5, 1.0, luma);
+  float midtoneWeight = 1.0 - shadowWeight - highlightWeight;
+
+  vec3 adjustment = u_shadows * shadowWeight
+                  + u_midtones * midtoneWeight
+                  + u_highlights * highlightWeight;
+
+  color.rgb += adjustment;
+  gl_FragColor = vec4(clamp(color.rgb, 0.0, 1.0), color.a);
+}

--- a/apps/web/src/lib/effects/definitions/color-balance/index.ts
+++ b/apps/web/src/lib/effects/definitions/color-balance/index.ts
@@ -1,0 +1,120 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./color-balance.frag.glsl";
+
+/** 3-way color grading: shadows, midtones, highlights */
+export const colorBalanceEffectDefinition: EffectDefinition = {
+	type: "color-balance",
+	name: "Color Balance",
+	category: EffectCategory.COLOR_TONE,
+	keywords: ["color balance", "grading", "shadows", "highlights", "midtones"],
+	params: [
+		{
+			key: "shadowsRed",
+			label: "Shadows Red",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "shadowsGreen",
+			label: "Shadows Green",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "shadowsBlue",
+			label: "Shadows Blue",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "midtonesRed",
+			label: "Midtones Red",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "midtonesGreen",
+			label: "Midtones Green",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "midtonesBlue",
+			label: "Midtones Blue",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "highlightsRed",
+			label: "Highlights Red",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "highlightsGreen",
+			label: "Highlights Green",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "highlightsBlue",
+			label: "Highlights Blue",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams }) => ({
+					u_shadows: [
+						getNumberParam(effectParams, "shadowsRed") / 200,
+						getNumberParam(effectParams, "shadowsGreen") / 200,
+						getNumberParam(effectParams, "shadowsBlue") / 200,
+					],
+					u_midtones: [
+						getNumberParam(effectParams, "midtonesRed") / 200,
+						getNumberParam(effectParams, "midtonesGreen") / 200,
+						getNumberParam(effectParams, "midtonesBlue") / 200,
+					],
+					u_highlights: [
+						getNumberParam(effectParams, "highlightsRed") / 200,
+						getNumberParam(effectParams, "highlightsGreen") / 200,
+						getNumberParam(effectParams, "highlightsBlue") / 200,
+					],
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/contrast/contrast.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/contrast/contrast.frag.glsl
@@ -1,0 +1,14 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_contrast;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  // Scale around midpoint 0.5
+  color.rgb = (color.rgb - 0.5) * u_contrast + 0.5;
+  gl_FragColor = vec4(clamp(color.rgb, 0.0, 1.0), color.a);
+}

--- a/apps/web/src/lib/effects/definitions/contrast/index.ts
+++ b/apps/web/src/lib/effects/definitions/contrast/index.ts
@@ -1,0 +1,34 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./contrast.frag.glsl";
+
+export const contrastEffectDefinition: EffectDefinition = {
+	type: "contrast",
+	name: "Contrast",
+	category: EffectCategory.COLOR_TONE,
+	keywords: ["contrast", "punch", "flat"],
+	params: [
+		{
+			key: "intensity",
+			label: "Intensity",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams }) => ({
+					// Map -100..100 → 0..2 (0 = no contrast, 1 = normal, 2 = max)
+					u_contrast: 1 + getNumberParam(effectParams, "intensity") / 100,
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/exposure/exposure.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/exposure/exposure.frag.glsl
@@ -1,0 +1,14 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_exposure;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  // Photographic exposure: multiply by 2^stops
+  color.rgb *= pow(2.0, u_exposure);
+  gl_FragColor = vec4(clamp(color.rgb, 0.0, 1.0), color.a);
+}

--- a/apps/web/src/lib/effects/definitions/exposure/index.ts
+++ b/apps/web/src/lib/effects/definitions/exposure/index.ts
@@ -1,0 +1,33 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./exposure.frag.glsl";
+
+export const exposureEffectDefinition: EffectDefinition = {
+	type: "exposure",
+	name: "Exposure",
+	category: EffectCategory.COLOR_TONE,
+	keywords: ["exposure", "ev", "stops", "overexpose", "underexpose"],
+	params: [
+		{
+			key: "stops",
+			label: "Stops",
+			type: "number",
+			default: 0,
+			min: -3,
+			max: 3,
+			step: 0.1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams }) => ({
+					u_exposure: getNumberParam(effectParams, "stops"),
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/eye-enhance/eye-enhance.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/eye-enhance/eye-enhance.frag.glsl
@@ -1,0 +1,16 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_brightness;
+uniform float u_contrast;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  // Brightness + contrast enhancement for eye regions
+  color.rgb += u_brightness;
+  color.rgb = (color.rgb - 0.5) * u_contrast + 0.5;
+  gl_FragColor = vec4(clamp(color.rgb, 0.0, 1.0), color.a);
+}

--- a/apps/web/src/lib/effects/definitions/eye-enhance/index.ts
+++ b/apps/web/src/lib/effects/definitions/eye-enhance/index.ts
@@ -1,0 +1,44 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./eye-enhance.frag.glsl";
+
+/** Eye enhance — brighten and sharpen eye regions */
+export const eyeEnhanceEffectDefinition: EffectDefinition = {
+	type: "eye-enhance",
+	name: "Eye Enhance",
+	category: EffectCategory.BEAUTY,
+	keywords: ["eye", "enhance", "bright", "sparkle", "beauty"],
+	params: [
+		{
+			key: "brightness",
+			label: "Brightness",
+			type: "number",
+			default: 20,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "contrast",
+			label: "Contrast",
+			type: "number",
+			default: 15,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams }) => ({
+					u_brightness: getNumberParam(effectParams, "brightness") / 400,
+					u_contrast: 1 + getNumberParam(effectParams, "contrast") / 200,
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/face-brighten/face-brighten.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/face-brighten/face-brighten.frag.glsl
@@ -1,0 +1,14 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_intensity;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  // Soft light blend — brightens without blowing out highlights
+  vec3 brightened = color.rgb + color.rgb * (1.0 - color.rgb) * u_intensity;
+  gl_FragColor = vec4(clamp(brightened, 0.0, 1.0), color.a);
+}

--- a/apps/web/src/lib/effects/definitions/face-brighten/index.ts
+++ b/apps/web/src/lib/effects/definitions/face-brighten/index.ts
@@ -1,0 +1,34 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./face-brighten.frag.glsl";
+
+/** Face brighten — soft light blend, optionally masked to face region */
+export const faceBrightenEffectDefinition: EffectDefinition = {
+	type: "face-brighten",
+	name: "Face Brighten",
+	category: EffectCategory.BEAUTY,
+	keywords: ["brighten", "face", "glow", "beauty", "luminous"],
+	params: [
+		{
+			key: "intensity",
+			label: "Intensity",
+			type: "number",
+			default: 30,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams }) => ({
+					u_intensity: getNumberParam(effectParams, "intensity") / 200,
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/film-grain/film-grain.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/film-grain/film-grain.frag.glsl
@@ -1,0 +1,23 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_intensity;
+uniform float u_grainSize;
+uniform float u_time;
+
+varying vec2 v_texCoord;
+
+// Hash-based pseudo-random noise
+float random(vec2 co) {
+  return fract(sin(dot(co, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  // Quantize UV by grain size for blocky noise
+  vec2 grainCoord = floor(v_texCoord * u_resolution / u_grainSize) * u_grainSize;
+  float noise = random(grainCoord + u_time) * 2.0 - 1.0;
+  color.rgb += noise * u_intensity;
+  gl_FragColor = vec4(clamp(color.rgb, 0.0, 1.0), color.a);
+}

--- a/apps/web/src/lib/effects/definitions/film-grain/index.ts
+++ b/apps/web/src/lib/effects/definitions/film-grain/index.ts
@@ -1,0 +1,47 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam, getBooleanParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./film-grain.frag.glsl";
+
+export const filmGrainEffectDefinition: EffectDefinition = {
+	type: "film-grain",
+	name: "Film Grain",
+	category: EffectCategory.ARTISTIC,
+	keywords: ["grain", "film", "noise", "analog", "texture", "vintage"],
+	params: [
+		{
+			key: "intensity",
+			label: "Intensity",
+			type: "number",
+			default: 30,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "size",
+			label: "Grain Size",
+			type: "number",
+			default: 2,
+			min: 1,
+			max: 10,
+			step: 1,
+		},
+		{ key: "animated", label: "Animated", type: "boolean", default: true },
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams, time }) => ({
+					u_intensity: getNumberParam(effectParams, "intensity") / 400,
+					u_grainSize: getNumberParam(effectParams, "size", 2),
+					u_time: getBooleanParam(effectParams, "animated", true)
+						? (time ?? 0)
+						: 0,
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/gamma/gamma.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/gamma/gamma.frag.glsl
@@ -1,0 +1,13 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_gamma;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  color.rgb = pow(color.rgb, vec3(1.0 / u_gamma));
+  gl_FragColor = vec4(clamp(color.rgb, 0.0, 1.0), color.a);
+}

--- a/apps/web/src/lib/effects/definitions/gamma/index.ts
+++ b/apps/web/src/lib/effects/definitions/gamma/index.ts
@@ -1,0 +1,33 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./gamma.frag.glsl";
+
+export const gammaEffectDefinition: EffectDefinition = {
+	type: "gamma",
+	name: "Gamma",
+	category: EffectCategory.COLOR_TONE,
+	keywords: ["gamma", "curve", "midtones"],
+	params: [
+		{
+			key: "value",
+			label: "Gamma",
+			type: "number",
+			default: 1.0,
+			min: 0.1,
+			max: 3.0,
+			step: 0.05,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams }) => ({
+					u_gamma: getNumberParam(effectParams, "value", 1.0),
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/glitch/glitch-pass1.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/glitch/glitch-pass1.frag.glsl
@@ -1,0 +1,29 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_intensity;
+uniform float u_colorSplit;
+uniform float u_time;
+
+varying vec2 v_texCoord;
+
+float random(vec2 co) {
+  return fract(sin(dot(co, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+void main() {
+  vec2 uv = v_texCoord;
+
+  // Block displacement — shift horizontal blocks randomly
+  float blockY = floor(uv.y * 20.0 + u_time * 3.0);
+  float blockShift = (random(vec2(blockY, u_time)) - 0.5) * u_intensity;
+  uv.x += blockShift;
+
+  // RGB channel split
+  float r = texture2D(u_texture, uv + vec2(u_colorSplit, 0.0)).r;
+  float g = texture2D(u_texture, uv).g;
+  float b = texture2D(u_texture, uv - vec2(u_colorSplit, 0.0)).b;
+
+  gl_FragColor = vec4(r, g, b, 1.0);
+}

--- a/apps/web/src/lib/effects/definitions/glitch/glitch-pass2.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/glitch/glitch-pass2.frag.glsl
@@ -1,0 +1,26 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_intensity;
+uniform float u_time;
+
+varying vec2 v_texCoord;
+
+float random(vec2 co) {
+  return fract(sin(dot(co, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+
+  // Scanlines
+  float scanline = sin(v_texCoord.y * u_resolution.y * 1.5) * 0.5 + 0.5;
+  color.rgb *= 1.0 - u_intensity * scanline * 0.15;
+
+  // Random noise flicker
+  float noise = random(v_texCoord + u_time) * u_intensity * 0.1;
+  color.rgb += noise;
+
+  gl_FragColor = vec4(clamp(color.rgb, 0.0, 1.0), color.a);
+}

--- a/apps/web/src/lib/effects/definitions/glitch/glitch.test.ts
+++ b/apps/web/src/lib/effects/definitions/glitch/glitch.test.ts
@@ -1,0 +1,183 @@
+import { describe, test, expect } from "bun:test";
+import { glitchEffectDefinition } from "./index";
+import { EffectCategory } from "@/lib/effects/categories";
+
+describe("Glitch Effect Definition", () => {
+	test("has correct type and name", () => {
+		expect(glitchEffectDefinition.type).toBe("glitch");
+		expect(glitchEffectDefinition.name).toBe("Glitch");
+	});
+
+	test("is categorized as artistic", () => {
+		expect(glitchEffectDefinition.category).toBe(EffectCategory.ARTISTIC);
+	});
+
+	test("has searchable keywords", () => {
+		expect(glitchEffectDefinition.keywords).toContain("glitch");
+		expect(glitchEffectDefinition.keywords).toContain("digital");
+		expect(glitchEffectDefinition.keywords).toContain("vhs");
+		expect(glitchEffectDefinition.keywords).toContain("corrupt");
+	});
+
+	test("has 3 params: intensity, speed, colorSplit", () => {
+		expect(glitchEffectDefinition.params.map((p) => p.key)).toEqual([
+			"intensity",
+			"speed",
+			"colorSplit",
+		]);
+	});
+
+	test("intensity param has correct defaults", () => {
+		const param = glitchEffectDefinition.params[0];
+		expect(param.key).toBe("intensity");
+		expect(param.type).toBe("number");
+		if (param.type === "number") {
+			expect(param.default).toBe(50);
+			expect(param.min).toBe(0);
+			expect(param.max).toBe(100);
+			expect(param.step).toBe(1);
+		}
+	});
+
+	test("speed param has correct defaults", () => {
+		const param = glitchEffectDefinition.params[1];
+		expect(param.key).toBe("speed");
+		expect(param.type).toBe("number");
+		if (param.type === "number") {
+			expect(param.default).toBe(50);
+			expect(param.min).toBe(0);
+			expect(param.max).toBe(100);
+			expect(param.step).toBe(1);
+		}
+	});
+
+	test("colorSplit param has correct defaults", () => {
+		const param = glitchEffectDefinition.params[2];
+		expect(param.key).toBe("colorSplit");
+		expect(param.type).toBe("number");
+		if (param.type === "number") {
+			expect(param.default).toBe(30);
+			expect(param.min).toBe(0);
+			expect(param.max).toBe(100);
+			expect(param.step).toBe(1);
+		}
+	});
+
+	test("renderer has 2 passes (block displacement + scanlines)", () => {
+		expect(glitchEffectDefinition.renderer.type).toBe("webgl");
+		expect(glitchEffectDefinition.renderer.passes).toHaveLength(2);
+	});
+
+	test("pass 1 uniforms scale intensity correctly", () => {
+		const pass1 = glitchEffectDefinition.renderer.passes[0];
+		const result = pass1.uniforms({
+			effectParams: { intensity: 50, speed: 50, colorSplit: 30 },
+			width: 1920,
+			height: 1080,
+			time: 1,
+		});
+		expect(result.u_intensity).toBe(0.05); // 50 / 1000 = 0.05
+	});
+
+	test("pass 1 colorSplit scales with width", () => {
+		const pass1 = glitchEffectDefinition.renderer.passes[0];
+		const at1920 = pass1.uniforms({
+			effectParams: { intensity: 50, speed: 50, colorSplit: 30 },
+			width: 1920,
+			height: 1080,
+			time: 1,
+		});
+		const at3840 = pass1.uniforms({
+			effectParams: { intensity: 50, speed: 50, colorSplit: 30 },
+			width: 3840,
+			height: 2160,
+			time: 1,
+		});
+		// colorSplit: 30 / (width * 10)
+		expect(at1920.u_colorSplit).toBeCloseTo(30 / 19200, 6);
+		expect(at3840.u_colorSplit).toBeCloseTo(30 / 38400, 6);
+		// Higher resolution = smaller colorSplit value
+		expect(at3840.u_colorSplit).toBeLessThan(at1920.u_colorSplit as number);
+	});
+
+	test("pass 1 time scales with speed", () => {
+		const pass1 = glitchEffectDefinition.renderer.passes[0];
+		const atSpeed0 = pass1.uniforms({
+			effectParams: { intensity: 50, speed: 0, colorSplit: 30 },
+			width: 1920,
+			height: 1080,
+			time: 2,
+		});
+		const atSpeed50 = pass1.uniforms({
+			effectParams: { intensity: 50, speed: 50, colorSplit: 30 },
+			width: 1920,
+			height: 1080,
+			time: 2,
+		});
+		const atSpeed100 = pass1.uniforms({
+			effectParams: { intensity: 50, speed: 100, colorSplit: 30 },
+			width: 1920,
+			height: 1080,
+			time: 2,
+		});
+		// time * (speed / 50)
+		expect(atSpeed0.u_time).toBe(0);
+		expect(atSpeed50.u_time).toBe(2); // 2 * (50 / 50) = 2
+		expect(atSpeed100.u_time).toBe(4); // 2 * (100 / 50) = 4
+	});
+
+	test("pass 2 uniforms scale intensity correctly", () => {
+		const pass2 = glitchEffectDefinition.renderer.passes[1];
+		const result = pass2.uniforms({
+			effectParams: { intensity: 50, speed: 50, colorSplit: 30 },
+			width: 1920,
+			height: 1080,
+			time: 1,
+		});
+		expect(result.u_intensity).toBe(0.5); // 50 / 100 = 0.5
+	});
+
+	test("pass 2 time scales with speed", () => {
+		const pass2 = glitchEffectDefinition.renderer.passes[1];
+		const atSpeed25 = pass2.uniforms({
+			effectParams: { intensity: 50, speed: 25, colorSplit: 30 },
+			width: 1920,
+			height: 1080,
+			time: 4,
+		});
+		expect(atSpeed25.u_time).toBe(2); // 4 * (25 / 50) = 2
+	});
+
+	test("both passes use time uniformly", () => {
+		const pass1 = glitchEffectDefinition.renderer.passes[0];
+		const pass2 = glitchEffectDefinition.renderer.passes[1];
+		const params = { intensity: 50, speed: 50, colorSplit: 30 };
+		const args = { effectParams: params, width: 1920, height: 1080, time: 3 };
+		const result1 = pass1.uniforms(args);
+		const result2 = pass2.uniforms(args);
+		// Both passes should have the same time value when speed is 50
+		expect(result1.u_time).toBe(3);
+		expect(result2.u_time).toBe(3);
+	});
+
+	test("handles undefined time gracefully", () => {
+		const pass1 = glitchEffectDefinition.renderer.passes[0];
+		const result = pass1.uniforms({
+			effectParams: { intensity: 50, speed: 50, colorSplit: 30 },
+			width: 1920,
+			height: 1080,
+		});
+		expect(result.u_time).toBe(0);
+	});
+
+	test("zero speed results in zero time", () => {
+		const pass1 = glitchEffectDefinition.renderer.passes[0];
+		const result = pass1.uniforms({
+			effectParams: { intensity: 50, speed: 0, colorSplit: 30 },
+			width: 1920,
+			height: 1080,
+			time: 100,
+		});
+		expect(result.u_time).toBe(0);
+	});
+});

--- a/apps/web/src/lib/effects/definitions/glitch/index.ts
+++ b/apps/web/src/lib/effects/definitions/glitch/index.ts
@@ -1,0 +1,65 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import pass1Shader from "./glitch-pass1.frag.glsl";
+import pass2Shader from "./glitch-pass2.frag.glsl";
+
+/** Digital glitch — 2-pass: block displacement + scanlines */
+export const glitchEffectDefinition: EffectDefinition = {
+	type: "glitch",
+	name: "Glitch",
+	category: EffectCategory.ARTISTIC,
+	keywords: ["glitch", "digital", "distortion", "corrupt", "vhs", "static"],
+	params: [
+		{
+			key: "intensity",
+			label: "Intensity",
+			type: "number",
+			default: 50,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "speed",
+			label: "Speed",
+			type: "number",
+			default: 50,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "colorSplit",
+			label: "Color Split",
+			type: "number",
+			default: 30,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader: pass1Shader,
+				uniforms: ({ effectParams, width, time }) => ({
+					u_intensity: getNumberParam(effectParams, "intensity") / 1000,
+					u_colorSplit:
+						getNumberParam(effectParams, "colorSplit") / (width * 10),
+					u_time:
+						(time ?? 0) * (getNumberParam(effectParams, "speed", 50) / 50),
+				}),
+			},
+			{
+				fragmentShader: pass2Shader,
+				uniforms: ({ effectParams, time }) => ({
+					u_intensity: getNumberParam(effectParams, "intensity") / 100,
+					u_time:
+						(time ?? 0) * (getNumberParam(effectParams, "speed", 50) / 50),
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/hue-shift/hue-shift.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/hue-shift/hue-shift.frag.glsl
@@ -1,0 +1,51 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_hueShift;
+
+varying vec2 v_texCoord;
+
+// RGB to HSL conversion
+vec3 rgb2hsl(vec3 c) {
+  float maxC = max(c.r, max(c.g, c.b));
+  float minC = min(c.r, min(c.g, c.b));
+  float l = (maxC + minC) * 0.5;
+  if (maxC == minC) return vec3(0.0, 0.0, l);
+  float d = maxC - minC;
+  float s = l > 0.5 ? d / (2.0 - maxC - minC) : d / (maxC + minC);
+  float h;
+  if (maxC == c.r) h = (c.g - c.b) / d + (c.g < c.b ? 6.0 : 0.0);
+  else if (maxC == c.g) h = (c.b - c.r) / d + 2.0;
+  else h = (c.r - c.g) / d + 4.0;
+  h /= 6.0;
+  return vec3(h, s, l);
+}
+
+// HSL to RGB conversion
+float hue2rgb(float p, float q, float t) {
+  if (t < 0.0) t += 1.0;
+  if (t > 1.0) t -= 1.0;
+  if (t < 1.0/6.0) return p + (q - p) * 6.0 * t;
+  if (t < 1.0/2.0) return q;
+  if (t < 2.0/3.0) return p + (q - p) * (2.0/3.0 - t) * 6.0;
+  return p;
+}
+
+vec3 hsl2rgb(vec3 hsl) {
+  if (hsl.y == 0.0) return vec3(hsl.z);
+  float q = hsl.z < 0.5 ? hsl.z * (1.0 + hsl.y) : hsl.z + hsl.y - hsl.z * hsl.y;
+  float p = 2.0 * hsl.z - q;
+  return vec3(
+    hue2rgb(p, q, hsl.x + 1.0/3.0),
+    hue2rgb(p, q, hsl.x),
+    hue2rgb(p, q, hsl.x - 1.0/3.0)
+  );
+}
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  vec3 hsl = rgb2hsl(color.rgb);
+  hsl.x = fract(hsl.x + u_hueShift);
+  gl_FragColor = vec4(hsl2rgb(hsl), color.a);
+}

--- a/apps/web/src/lib/effects/definitions/hue-shift/index.ts
+++ b/apps/web/src/lib/effects/definitions/hue-shift/index.ts
@@ -1,0 +1,34 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./hue-shift.frag.glsl";
+
+export const hueShiftEffectDefinition: EffectDefinition = {
+	type: "hue-shift",
+	name: "Hue Shift",
+	category: EffectCategory.COLOR_TONE,
+	keywords: ["hue", "shift", "rotate", "color wheel", "tint"],
+	params: [
+		{
+			key: "degrees",
+			label: "Degrees",
+			type: "number",
+			default: 0,
+			min: 0,
+			max: 360,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams }) => ({
+					// Convert degrees to 0..1 range for HSL rotation
+					u_hueShift: getNumberParam(effectParams, "degrees") / 360,
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/index.ts
+++ b/apps/web/src/lib/effects/definitions/index.ts
@@ -1,7 +1,58 @@
 import { effectsRegistry } from "../registry";
 import { blurEffectDefinition } from "./blur";
+import { blushEffectDefinition } from "./blush";
+import { brightnessEffectDefinition } from "./brightness";
+import { chromaticAberrationEffectDefinition } from "./chromatic-aberration";
+import { colorBalanceEffectDefinition } from "./color-balance";
+import { contrastEffectDefinition } from "./contrast";
+import { exposureEffectDefinition } from "./exposure";
+import { eyeEnhanceEffectDefinition } from "./eye-enhance";
+import { faceBrightenEffectDefinition } from "./face-brighten";
+import { filmGrainEffectDefinition } from "./film-grain";
+import { gammaEffectDefinition } from "./gamma";
+import { glitchEffectDefinition } from "./glitch";
+import { hueShiftEffectDefinition } from "./hue-shift";
+import { neonGlowEffectDefinition } from "./neon-glow";
+import { oilPaintEffectDefinition } from "./oil-paint";
+import { pixelateEffectDefinition } from "./pixelate";
+import { saturationEffectDefinition } from "./saturation";
+import { sharpenEffectDefinition } from "./sharpen";
+import { sketchEffectDefinition } from "./sketch";
+import { skinSmoothEffectDefinition } from "./skin-smooth";
+import { slimFaceEffectDefinition } from "./slim-face";
+import { teethWhitenEffectDefinition } from "./teeth-whiten";
+import { temperatureEffectDefinition } from "./temperature";
+import { vignetteEffectDefinition } from "./vignette";
 
-const defaultEffects = [blurEffectDefinition];
+const defaultEffects = [
+	// Artistic
+	blurEffectDefinition,
+	vignetteEffectDefinition,
+	filmGrainEffectDefinition,
+	sharpenEffectDefinition,
+	pixelateEffectDefinition,
+	chromaticAberrationEffectDefinition,
+	glitchEffectDefinition,
+	neonGlowEffectDefinition,
+	sketchEffectDefinition,
+	oilPaintEffectDefinition,
+	// Beauty
+	skinSmoothEffectDefinition,
+	faceBrightenEffectDefinition,
+	eyeEnhanceEffectDefinition,
+	teethWhitenEffectDefinition,
+	blushEffectDefinition,
+	slimFaceEffectDefinition,
+	// Color & Tone
+	brightnessEffectDefinition,
+	contrastEffectDefinition,
+	saturationEffectDefinition,
+	hueShiftEffectDefinition,
+	temperatureEffectDefinition,
+	exposureEffectDefinition,
+	gammaEffectDefinition,
+	colorBalanceEffectDefinition,
+];
 
 export function registerDefaultEffects(): void {
 	for (const definition of defaultEffects) {

--- a/apps/web/src/lib/effects/definitions/neon-glow/index.ts
+++ b/apps/web/src/lib/effects/definitions/neon-glow/index.ts
@@ -1,0 +1,55 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { hexToRgb } from "@/lib/effects/utils/color";
+import { getNumberParam, getStringParam } from "@/lib/effects/utils/params";
+import pass1Shader from "./neon-glow-pass1.frag.glsl";
+import pass2Shader from "./neon-glow-pass2.frag.glsl";
+
+/** Neon glow — 2-pass: extract bright areas, blur + tint */
+export const neonGlowEffectDefinition: EffectDefinition = {
+	type: "neon-glow",
+	name: "Neon Glow",
+	category: EffectCategory.ARTISTIC,
+	keywords: ["neon", "glow", "bloom", "light", "bright", "luminous"],
+	params: [
+		{
+			key: "intensity",
+			label: "Intensity",
+			type: "number",
+			default: 50,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+		{ key: "color", label: "Glow Color", type: "color", default: "#00ff88" },
+		{
+			key: "threshold",
+			label: "Threshold",
+			type: "number",
+			default: 50,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader: pass1Shader,
+				uniforms: ({ effectParams }) => ({
+					u_threshold: getNumberParam(effectParams, "threshold") / 100,
+				}),
+			},
+			{
+				fragmentShader: pass2Shader,
+				uniforms: ({ effectParams }) => ({
+					u_intensity: getNumberParam(effectParams, "intensity") / 50,
+					u_glowColor: hexToRgb(
+						getStringParam(effectParams, "color", "#00ff88"),
+					),
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/neon-glow/neon-glow-pass1.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/neon-glow/neon-glow-pass1.frag.glsl
@@ -1,0 +1,15 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_threshold;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  float luma = dot(color.rgb, vec3(0.2126, 0.7152, 0.0722));
+  // Extract only bright areas above threshold
+  float mask = smoothstep(u_threshold, u_threshold + 0.1, luma);
+  gl_FragColor = vec4(color.rgb * mask, color.a);
+}

--- a/apps/web/src/lib/effects/definitions/neon-glow/neon-glow-pass2.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/neon-glow/neon-glow-pass2.frag.glsl
@@ -1,0 +1,25 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_intensity;
+uniform vec3 u_glowColor;
+
+varying vec2 v_texCoord;
+
+void main() {
+  // Simple box blur of the bright extraction
+  vec2 texel = 1.0 / u_resolution;
+  vec4 sum = vec4(0.0);
+  for (int x = -3; x <= 3; x++) {
+    for (int y = -3; y <= 3; y++) {
+      sum += texture2D(u_texture, v_texCoord + vec2(float(x), float(y)) * texel * 2.0);
+    }
+  }
+  sum /= 49.0;
+
+  // Tint with glow color and blend additively with original
+  vec4 original = texture2D(u_texture, v_texCoord);
+  vec3 glow = sum.rgb * u_glowColor * u_intensity;
+  gl_FragColor = vec4(clamp(original.rgb + glow, 0.0, 1.0), original.a);
+}

--- a/apps/web/src/lib/effects/definitions/oil-paint/index.ts
+++ b/apps/web/src/lib/effects/definitions/oil-paint/index.ts
@@ -1,0 +1,50 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import pass1Shader from "./oil-paint-pass1.frag.glsl";
+import pass2Shader from "./oil-paint-pass2.frag.glsl";
+
+/** Oil paint — 2-pass: color quantization + neighborhood averaging (Kuwahara-inspired) */
+export const oilPaintEffectDefinition: EffectDefinition = {
+	type: "oil-paint",
+	name: "Oil Paint",
+	category: EffectCategory.ARTISTIC,
+	keywords: ["oil paint", "painting", "artistic", "impressionist", "canvas"],
+	params: [
+		{
+			key: "radius",
+			label: "Radius",
+			type: "number",
+			default: 4,
+			min: 1,
+			max: 5,
+			step: 1,
+		},
+		{
+			key: "levels",
+			label: "Color Levels",
+			type: "number",
+			default: 8,
+			min: 2,
+			max: 20,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader: pass1Shader,
+				uniforms: ({ effectParams }) => ({
+					u_levels: getNumberParam(effectParams, "levels", 8),
+				}),
+			},
+			{
+				fragmentShader: pass2Shader,
+				uniforms: ({ effectParams }) => ({
+					u_radius: getNumberParam(effectParams, "radius", 4),
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/oil-paint/oil-paint-pass1.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/oil-paint/oil-paint-pass1.frag.glsl
@@ -1,0 +1,14 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_levels;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  // Quantize colors to discrete levels
+  color.rgb = floor(color.rgb * u_levels + 0.5) / u_levels;
+  gl_FragColor = color;
+}

--- a/apps/web/src/lib/effects/definitions/oil-paint/oil-paint-pass2.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/oil-paint/oil-paint-pass2.frag.glsl
@@ -1,0 +1,24 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_radius;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec2 texel = 1.0 / u_resolution;
+  int r = int(u_radius);
+
+  // Simplified Kuwahara: find mode color in neighborhood
+  vec3 sum = vec3(0.0);
+  float count = 0.0;
+  for (int x = -5; x <= 5; x++) {
+    for (int y = -5; y <= 5; y++) {
+      if (x*x + y*y > r*r) continue;
+      sum += texture2D(u_texture, v_texCoord + vec2(float(x), float(y)) * texel).rgb;
+      count += 1.0;
+    }
+  }
+  gl_FragColor = vec4(sum / count, 1.0);
+}

--- a/apps/web/src/lib/effects/definitions/pixelate/index.ts
+++ b/apps/web/src/lib/effects/definitions/pixelate/index.ts
@@ -1,0 +1,33 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./pixelate.frag.glsl";
+
+export const pixelateEffectDefinition: EffectDefinition = {
+	type: "pixelate",
+	name: "Pixelate",
+	category: EffectCategory.ARTISTIC,
+	keywords: ["pixelate", "mosaic", "block", "retro", "pixel"],
+	params: [
+		{
+			key: "blockSize",
+			label: "Block Size",
+			type: "number",
+			default: 10,
+			min: 2,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams }) => ({
+					u_blockSize: getNumberParam(effectParams, "blockSize", 10),
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/pixelate/pixelate.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/pixelate/pixelate.frag.glsl
@@ -1,0 +1,14 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_blockSize;
+
+varying vec2 v_texCoord;
+
+void main() {
+  // Floor UV to block grid, sample from block center
+  vec2 blockCoord = floor(v_texCoord * u_resolution / u_blockSize) * u_blockSize;
+  vec2 sampleUV = (blockCoord + u_blockSize * 0.5) / u_resolution;
+  gl_FragColor = texture2D(u_texture, sampleUV);
+}

--- a/apps/web/src/lib/effects/definitions/saturation/index.ts
+++ b/apps/web/src/lib/effects/definitions/saturation/index.ts
@@ -1,0 +1,34 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./saturation.frag.glsl";
+
+export const saturationEffectDefinition: EffectDefinition = {
+	type: "saturation",
+	name: "Saturation",
+	category: EffectCategory.COLOR_TONE,
+	keywords: ["saturation", "vibrance", "color", "desaturate", "grayscale"],
+	params: [
+		{
+			key: "intensity",
+			label: "Intensity",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams }) => ({
+					// Map -100..100 → 0..2 (0 = grayscale, 1 = normal, 2 = oversaturated)
+					u_saturation: 1 + getNumberParam(effectParams, "intensity") / 100,
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/saturation/saturation.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/saturation/saturation.frag.glsl
@@ -1,0 +1,15 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_saturation;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  // BT.709 luminance coefficients
+  float luma = dot(color.rgb, vec3(0.2126, 0.7152, 0.0722));
+  color.rgb = mix(vec3(luma), color.rgb, u_saturation);
+  gl_FragColor = vec4(clamp(color.rgb, 0.0, 1.0), color.a);
+}

--- a/apps/web/src/lib/effects/definitions/sharpen/index.ts
+++ b/apps/web/src/lib/effects/definitions/sharpen/index.ts
@@ -1,0 +1,33 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./sharpen.frag.glsl";
+
+export const sharpenEffectDefinition: EffectDefinition = {
+	type: "sharpen",
+	name: "Sharpen",
+	category: EffectCategory.ARTISTIC,
+	keywords: ["sharpen", "crisp", "detail", "enhance", "unsharp mask"],
+	params: [
+		{
+			key: "intensity",
+			label: "Intensity",
+			type: "number",
+			default: 50,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams }) => ({
+					u_intensity: getNumberParam(effectParams, "intensity") / 100,
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/sharpen/sharpen.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/sharpen/sharpen.frag.glsl
@@ -1,0 +1,20 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_intensity;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec2 texel = 1.0 / u_resolution;
+  // Unsharp mask: center - average of neighbors
+  vec4 center = texture2D(u_texture, v_texCoord);
+  vec4 top    = texture2D(u_texture, v_texCoord + vec2(0.0, texel.y));
+  vec4 bottom = texture2D(u_texture, v_texCoord - vec2(0.0, texel.y));
+  vec4 left   = texture2D(u_texture, v_texCoord - vec2(texel.x, 0.0));
+  vec4 right  = texture2D(u_texture, v_texCoord + vec2(texel.x, 0.0));
+
+  vec4 edges = center * 4.0 - top - bottom - left - right;
+  gl_FragColor = vec4(clamp(center.rgb + edges.rgb * u_intensity, 0.0, 1.0), center.a);
+}

--- a/apps/web/src/lib/effects/definitions/sharpen/sharpen.test.ts
+++ b/apps/web/src/lib/effects/definitions/sharpen/sharpen.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect } from "bun:test";
+import { sharpenEffectDefinition } from "./index";
+import { EffectCategory } from "@/lib/effects/categories";
+
+describe("Sharpen Effect Definition", () => {
+	test("has correct type and name", () => {
+		expect(sharpenEffectDefinition.type).toBe("sharpen");
+		expect(sharpenEffectDefinition.name).toBe("Sharpen");
+	});
+
+	test("is categorized as artistic", () => {
+		expect(sharpenEffectDefinition.category).toBe(EffectCategory.ARTISTIC);
+	});
+
+	test("has searchable keywords", () => {
+		expect(sharpenEffectDefinition.keywords).toContain("sharpen");
+		expect(sharpenEffectDefinition.keywords).toContain("crisp");
+		expect(sharpenEffectDefinition.keywords).toContain("detail");
+		expect(sharpenEffectDefinition.keywords).toContain("unsharp mask");
+	});
+
+	test("has single intensity param", () => {
+		expect(sharpenEffectDefinition.params).toHaveLength(1);
+		expect(sharpenEffectDefinition.params[0].key).toBe("intensity");
+	});
+
+	test("intensity param has correct defaults", () => {
+		const param = sharpenEffectDefinition.params[0];
+		expect(param.type).toBe("number");
+		if (param.type === "number") {
+			expect(param.default).toBe(50);
+			expect(param.min).toBe(0);
+			expect(param.max).toBe(100);
+			expect(param.step).toBe(1);
+		}
+	});
+
+	test("renderer has single pass", () => {
+		expect(sharpenEffectDefinition.renderer.type).toBe("webgl");
+		expect(sharpenEffectDefinition.renderer.passes).toHaveLength(1);
+	});
+
+	test("uniforms normalize intensity to 0..1 range", () => {
+		const pass = sharpenEffectDefinition.renderer.passes[0];
+		const at0 = pass.uniforms({
+			effectParams: { intensity: 0 },
+			width: 1920,
+			height: 1080,
+		});
+		const at100 = pass.uniforms({
+			effectParams: { intensity: 100 },
+			width: 1920,
+			height: 1080,
+		});
+		expect(at0.u_intensity).toBe(0);
+		expect(at100.u_intensity).toBe(1);
+	});
+
+	test("uniforms at 50% intensity", () => {
+		const pass = sharpenEffectDefinition.renderer.passes[0];
+		const result = pass.uniforms({
+			effectParams: { intensity: 50 },
+			width: 1920,
+			height: 1080,
+		});
+		expect(result.u_intensity).toBe(0.5);
+	});
+
+	test("uniforms at various intensity levels", () => {
+		const pass = sharpenEffectDefinition.renderer.passes[0];
+		const at25 = pass.uniforms({
+			effectParams: { intensity: 25 },
+			width: 1920,
+			height: 1080,
+		});
+		const at75 = pass.uniforms({
+			effectParams: { intensity: 75 },
+			width: 1920,
+			height: 1080,
+		});
+		expect(at25.u_intensity).toBe(0.25);
+		expect(at75.u_intensity).toBe(0.75);
+	});
+});

--- a/apps/web/src/lib/effects/definitions/sketch/index.ts
+++ b/apps/web/src/lib/effects/definitions/sketch/index.ts
@@ -1,0 +1,50 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import pass1Shader from "./sketch-pass1.frag.glsl";
+import pass2Shader from "./sketch-pass2.frag.glsl";
+
+/** Sketch/outline — 2-pass: Sobel edge detection + threshold */
+export const sketchEffectDefinition: EffectDefinition = {
+	type: "sketch",
+	name: "Sketch",
+	category: EffectCategory.ARTISTIC,
+	keywords: ["sketch", "outline", "pencil", "edge", "drawing", "line art"],
+	params: [
+		{
+			key: "threshold",
+			label: "Threshold",
+			type: "number",
+			default: 50,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "lineWidth",
+			label: "Line Width",
+			type: "number",
+			default: 1,
+			min: 1,
+			max: 5,
+			step: 0.5,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader: pass1Shader,
+				uniforms: ({ effectParams }) => ({
+					u_lineWidth: getNumberParam(effectParams, "lineWidth", 1),
+				}),
+			},
+			{
+				fragmentShader: pass2Shader,
+				uniforms: ({ effectParams }) => ({
+					u_threshold: getNumberParam(effectParams, "threshold") / 100,
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/sketch/sketch-pass1.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/sketch/sketch-pass1.frag.glsl
@@ -1,0 +1,27 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_lineWidth;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec2 texel = u_lineWidth / u_resolution;
+
+  // Sobel edge detection on luminance
+  float tl = dot(texture2D(u_texture, v_texCoord + vec2(-texel.x, texel.y)).rgb, vec3(0.2126, 0.7152, 0.0722));
+  float t  = dot(texture2D(u_texture, v_texCoord + vec2(0.0, texel.y)).rgb, vec3(0.2126, 0.7152, 0.0722));
+  float tr = dot(texture2D(u_texture, v_texCoord + vec2(texel.x, texel.y)).rgb, vec3(0.2126, 0.7152, 0.0722));
+  float l  = dot(texture2D(u_texture, v_texCoord + vec2(-texel.x, 0.0)).rgb, vec3(0.2126, 0.7152, 0.0722));
+  float r  = dot(texture2D(u_texture, v_texCoord + vec2(texel.x, 0.0)).rgb, vec3(0.2126, 0.7152, 0.0722));
+  float bl = dot(texture2D(u_texture, v_texCoord + vec2(-texel.x, -texel.y)).rgb, vec3(0.2126, 0.7152, 0.0722));
+  float b  = dot(texture2D(u_texture, v_texCoord + vec2(0.0, -texel.y)).rgb, vec3(0.2126, 0.7152, 0.0722));
+  float br = dot(texture2D(u_texture, v_texCoord + vec2(texel.x, -texel.y)).rgb, vec3(0.2126, 0.7152, 0.0722));
+
+  float gx = -tl - 2.0*l - bl + tr + 2.0*r + br;
+  float gy = -tl - 2.0*t - tr + bl + 2.0*b + br;
+  float edge = sqrt(gx*gx + gy*gy);
+
+  gl_FragColor = vec4(vec3(edge), 1.0);
+}

--- a/apps/web/src/lib/effects/definitions/sketch/sketch-pass2.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/sketch/sketch-pass2.frag.glsl
@@ -1,0 +1,15 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_threshold;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec4 edges = texture2D(u_texture, v_texCoord);
+  float edge = edges.r;
+  // Threshold and invert for sketch look (dark lines on white)
+  float line = step(u_threshold, edge);
+  gl_FragColor = vec4(vec3(1.0 - line), 1.0);
+}

--- a/apps/web/src/lib/effects/definitions/skin-smooth/index.ts
+++ b/apps/web/src/lib/effects/definitions/skin-smooth/index.ts
@@ -1,0 +1,41 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import pass1Shader from "./skin-smooth-pass1.frag.glsl";
+import pass2Shader from "./skin-smooth-pass2.frag.glsl";
+
+/** Skin smooth — bilateral filter that preserves edges, optionally masked to face region */
+export const skinSmoothEffectDefinition: EffectDefinition = {
+	type: "skin-smooth",
+	name: "Skin Smooth",
+	category: EffectCategory.BEAUTY,
+	keywords: ["skin", "smooth", "beauty", "soft", "face", "portrait"],
+	params: [
+		{
+			key: "intensity",
+			label: "Intensity",
+			type: "number",
+			default: 50,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader: pass1Shader,
+				uniforms: ({ effectParams }) => ({
+					u_intensity: (getNumberParam(effectParams, "intensity") / 100) * 3,
+				}),
+			},
+			{
+				fragmentShader: pass2Shader,
+				uniforms: ({ context }) => ({
+					u_faceMaskEnabled: context?.faceDetected ? 1 : 0,
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/skin-smooth/skin-smooth-pass1.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/skin-smooth/skin-smooth-pass1.frag.glsl
@@ -1,0 +1,34 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_intensity;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec2 texel = 1.0 / u_resolution;
+  vec4 center = texture2D(u_texture, v_texCoord);
+
+  // Bilateral filter: blur that preserves edges
+  vec4 sum = vec4(0.0);
+  float totalWeight = 0.0;
+
+  for (int x = -4; x <= 4; x++) {
+    for (int y = -4; y <= 4; y++) {
+      vec2 offset = vec2(float(x), float(y)) * texel * u_intensity;
+      vec4 sample_ = texture2D(u_texture, v_texCoord + offset);
+
+      // Edge-aware weight: similar colors get higher weight
+      float colorDist = distance(center.rgb, sample_.rgb);
+      float spatialWeight = exp(-float(x*x + y*y) / 32.0);
+      float colorWeight = exp(-colorDist * colorDist / 0.05);
+      float weight = spatialWeight * colorWeight;
+
+      sum += sample_ * weight;
+      totalWeight += weight;
+    }
+  }
+
+  gl_FragColor = vec4(sum.rgb / totalWeight, center.a);
+}

--- a/apps/web/src/lib/effects/definitions/skin-smooth/skin-smooth-pass2.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/skin-smooth/skin-smooth-pass2.frag.glsl
@@ -1,0 +1,14 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_faceMaskEnabled;
+
+varying vec2 v_texCoord;
+
+void main() {
+  // Pass-through — the actual face mask blending is done by the renderer
+  // when face detection is available. Without a mask, the smoothing
+  // applies uniformly (acceptable fallback).
+  gl_FragColor = texture2D(u_texture, v_texCoord);
+}

--- a/apps/web/src/lib/effects/definitions/slim-face/index.ts
+++ b/apps/web/src/lib/effects/definitions/slim-face/index.ts
@@ -1,0 +1,45 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./slim-face.frag.glsl";
+
+/** Slim face — pinch warp along jawline for face slimming */
+export const slimFaceEffectDefinition: EffectDefinition = {
+	type: "slim-face",
+	name: "Slim Face",
+	category: EffectCategory.BEAUTY,
+	keywords: ["slim", "face", "thin", "jawline", "beauty", "reshape"],
+	params: [
+		{
+			key: "intensity",
+			label: "Intensity",
+			type: "number",
+			default: 20,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams, context }) => {
+					const jawCenter =
+						context?.jawPoints && context.jawPoints.length >= 2
+							? context.jawPoints.slice(0, 2)
+							: null;
+
+					return {
+						// No-op when jaw landmarks are missing to avoid warping arbitrary content
+						u_intensity: jawCenter
+							? getNumberParam(effectParams, "intensity") / 100
+							: 0,
+						u_jawCenter: jawCenter ?? [0.5, 0.6],
+					};
+				},
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/slim-face/slim-face.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/slim-face/slim-face.frag.glsl
@@ -1,0 +1,25 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_intensity;
+uniform vec2 u_jawCenter;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec2 uv = v_texCoord;
+
+  // Simple pinch warp toward center along jawline
+  vec2 toCenter = u_jawCenter - uv;
+  float dist = length(toCenter);
+  float radius = 0.3;
+
+  if (dist < radius) {
+    float falloff = 1.0 - smoothstep(0.0, radius, dist);
+    // Pull pixels inward (toward jaw center) for slimming
+    uv += toCenter * falloff * u_intensity * 0.05;
+  }
+
+  gl_FragColor = texture2D(u_texture, uv);
+}

--- a/apps/web/src/lib/effects/definitions/teeth-whiten/index.ts
+++ b/apps/web/src/lib/effects/definitions/teeth-whiten/index.ts
@@ -1,0 +1,34 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./teeth-whiten.frag.glsl";
+
+/** Teeth whiten — desaturate + brighten, ideally masked to mouth region */
+export const teethWhitenEffectDefinition: EffectDefinition = {
+	type: "teeth-whiten",
+	name: "Teeth Whiten",
+	category: EffectCategory.BEAUTY,
+	keywords: ["teeth", "whiten", "smile", "beauty", "dental"],
+	params: [
+		{
+			key: "intensity",
+			label: "Intensity",
+			type: "number",
+			default: 40,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams }) => ({
+					u_intensity: getNumberParam(effectParams, "intensity") / 200,
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/teeth-whiten/teeth-whiten.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/teeth-whiten/teeth-whiten.frag.glsl
@@ -1,0 +1,16 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_intensity;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  // Desaturate + brighten for whitening effect
+  float luma = dot(color.rgb, vec3(0.2126, 0.7152, 0.0722));
+  vec3 desaturated = mix(color.rgb, vec3(luma), u_intensity);
+  vec3 brightened = desaturated + u_intensity * 0.1;
+  gl_FragColor = vec4(clamp(brightened, 0.0, 1.0), color.a);
+}

--- a/apps/web/src/lib/effects/definitions/temperature/index.ts
+++ b/apps/web/src/lib/effects/definitions/temperature/index.ts
@@ -1,0 +1,33 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./temperature.frag.glsl";
+
+export const temperatureEffectDefinition: EffectDefinition = {
+	type: "temperature",
+	name: "Temperature",
+	category: EffectCategory.COLOR_TONE,
+	keywords: ["temperature", "warm", "cool", "white balance", "warmth"],
+	params: [
+		{
+			key: "warmth",
+			label: "Warmth",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams }) => ({
+					u_temperature: getNumberParam(effectParams, "warmth") / 400,
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/temperature/temperature.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/temperature/temperature.frag.glsl
@@ -1,0 +1,15 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_temperature;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  // Warm = boost red, reduce blue. Cool = opposite.
+  color.r += u_temperature;
+  color.b -= u_temperature;
+  gl_FragColor = vec4(clamp(color.rgb, 0.0, 1.0), color.a);
+}

--- a/apps/web/src/lib/effects/definitions/vignette/index.ts
+++ b/apps/web/src/lib/effects/definitions/vignette/index.ts
@@ -1,0 +1,54 @@
+import type { EffectDefinition } from "@/lib/effects/types";
+import { EffectCategory } from "@/lib/effects/categories";
+import { getNumberParam } from "@/lib/effects/utils/params";
+import fragmentShader from "./vignette.frag.glsl";
+
+export const vignetteEffectDefinition: EffectDefinition = {
+	type: "vignette",
+	name: "Vignette",
+	category: EffectCategory.ARTISTIC,
+	keywords: ["vignette", "border", "darken", "edges", "cinematic"],
+	params: [
+		{
+			key: "intensity",
+			label: "Intensity",
+			type: "number",
+			default: 50,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "radius",
+			label: "Radius",
+			type: "number",
+			default: 80,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "softness",
+			label: "Softness",
+			type: "number",
+			default: 50,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		passes: [
+			{
+				fragmentShader,
+				uniforms: ({ effectParams }) => ({
+					u_intensity: getNumberParam(effectParams, "intensity") / 100,
+					u_radius:
+						(getNumberParam(effectParams, "radius") / 100) * Math.SQRT1_2,
+					u_softness: (getNumberParam(effectParams, "softness") / 100) * 0.5,
+				}),
+			},
+		],
+	},
+};

--- a/apps/web/src/lib/effects/definitions/vignette/vignette.frag.glsl
+++ b/apps/web/src/lib/effects/definitions/vignette/vignette.frag.glsl
@@ -1,0 +1,20 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_intensity;
+uniform float u_radius;
+uniform float u_softness;
+
+varying vec2 v_texCoord;
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  // Distance from center (0..~0.707 for corners)
+  vec2 center = v_texCoord - 0.5;
+  float dist = length(center);
+  // Darken based on distance, radius, and softness
+  float vignette = smoothstep(u_radius, u_radius - u_softness, dist);
+  color.rgb *= mix(1.0, vignette, u_intensity);
+  gl_FragColor = color;
+}

--- a/apps/web/src/lib/effects/definitions/vignette/vignette.test.ts
+++ b/apps/web/src/lib/effects/definitions/vignette/vignette.test.ts
@@ -1,0 +1,131 @@
+import { describe, test, expect } from "bun:test";
+import { vignetteEffectDefinition } from "./index";
+import { EffectCategory } from "@/lib/effects/categories";
+
+describe("Vignette Effect Definition", () => {
+	test("has correct type and name", () => {
+		expect(vignetteEffectDefinition.type).toBe("vignette");
+		expect(vignetteEffectDefinition.name).toBe("Vignette");
+	});
+
+	test("is categorized as artistic", () => {
+		expect(vignetteEffectDefinition.category).toBe(EffectCategory.ARTISTIC);
+	});
+
+	test("has searchable keywords", () => {
+		expect(vignetteEffectDefinition.keywords).toContain("vignette");
+		expect(vignetteEffectDefinition.keywords).toContain("cinematic");
+		expect(vignetteEffectDefinition.keywords).toContain("edges");
+	});
+
+	test("has 3 params: intensity, radius, softness", () => {
+		expect(vignetteEffectDefinition.params.map((p) => p.key)).toEqual([
+			"intensity",
+			"radius",
+			"softness",
+		]);
+	});
+
+	test("intensity param has correct defaults", () => {
+		const param = vignetteEffectDefinition.params[0];
+		expect(param.key).toBe("intensity");
+		expect(param.type).toBe("number");
+		if (param.type === "number") {
+			expect(param.default).toBe(50);
+			expect(param.min).toBe(0);
+			expect(param.max).toBe(100);
+			expect(param.step).toBe(1);
+		}
+	});
+
+	test("radius param has correct defaults", () => {
+		const param = vignetteEffectDefinition.params[1];
+		expect(param.key).toBe("radius");
+		expect(param.type).toBe("number");
+		if (param.type === "number") {
+			expect(param.default).toBe(80);
+			expect(param.min).toBe(0);
+			expect(param.max).toBe(100);
+			expect(param.step).toBe(1);
+		}
+	});
+
+	test("softness param has correct defaults", () => {
+		const param = vignetteEffectDefinition.params[2];
+		expect(param.key).toBe("softness");
+		expect(param.type).toBe("number");
+		if (param.type === "number") {
+			expect(param.default).toBe(50);
+			expect(param.min).toBe(0);
+			expect(param.max).toBe(100);
+			expect(param.step).toBe(1);
+		}
+	});
+
+	test("renderer has single pass", () => {
+		expect(vignetteEffectDefinition.renderer.type).toBe("webgl");
+		expect(vignetteEffectDefinition.renderer.passes).toHaveLength(1);
+	});
+
+	test("uniforms normalize intensity to 0..1 range", () => {
+		const pass = vignetteEffectDefinition.renderer.passes[0];
+		const at0 = pass.uniforms({
+			effectParams: { intensity: 0, radius: 50, softness: 50 },
+			width: 1920,
+			height: 1080,
+		});
+		const at100 = pass.uniforms({
+			effectParams: { intensity: 100, radius: 50, softness: 50 },
+			width: 1920,
+			height: 1080,
+		});
+		expect(at0.u_intensity).toBe(0);
+		expect(at100.u_intensity).toBe(1);
+	});
+
+	test("uniforms scale radius correctly", () => {
+		const pass = vignetteEffectDefinition.renderer.passes[0];
+		const at0 = pass.uniforms({
+			effectParams: { intensity: 50, radius: 0, softness: 50 },
+			width: 1920,
+			height: 1080,
+		});
+		const at100 = pass.uniforms({
+			effectParams: { intensity: 50, radius: 100, softness: 50 },
+			width: 1920,
+			height: 1080,
+		});
+		// radius: 100 / 100 * 0.707 = 0.707
+		expect(at0.u_radius).toBe(0);
+		expect(at100.u_radius).toBeCloseTo(Math.SQRT1_2, 3);
+	});
+
+	test("uniforms scale softness correctly", () => {
+		const pass = vignetteEffectDefinition.renderer.passes[0];
+		const at0 = pass.uniforms({
+			effectParams: { intensity: 50, radius: 50, softness: 0 },
+			width: 1920,
+			height: 1080,
+		});
+		const at100 = pass.uniforms({
+			effectParams: { intensity: 50, radius: 50, softness: 100 },
+			width: 1920,
+			height: 1080,
+		});
+		// softness: 100 / 100 * 0.5 = 0.5
+		expect(at0.u_softness).toBe(0);
+		expect(at100.u_softness).toBe(0.5);
+	});
+
+	test("uniforms with default values", () => {
+		const pass = vignetteEffectDefinition.renderer.passes[0];
+		const result = pass.uniforms({
+			effectParams: { intensity: 50, radius: 80, softness: 50 },
+			width: 1920,
+			height: 1080,
+		});
+		expect(result.u_intensity).toBe(0.5);
+		expect(result.u_radius).toBeCloseTo(0.5656, 3); // 80 / 100 * 0.707
+		expect(result.u_softness).toBe(0.25); // 50 / 100 * 0.5
+	});
+});

--- a/apps/web/src/lib/effects/index.ts
+++ b/apps/web/src/lib/effects/index.ts
@@ -2,29 +2,39 @@ import { generateUUID } from "@/utils/id";
 import { buildDefaultParamValues } from "@/lib/registry";
 import { effectsRegistry } from "./registry";
 import type { ParamValues } from "@/lib/params";
-import type { Effect, EffectDefinition, ResolvedEffectPass } from "@/lib/effects/types";
+import type {
+	Effect,
+	EffectContext,
+	EffectDefinition,
+	ResolvedEffectPass,
+} from "@/lib/effects/types";
 import { VISUAL_ELEMENT_TYPES } from "@/lib/timeline";
 
 export { effectsRegistry } from "./registry";
 export { registerDefaultEffects } from "./definitions";
+export { registerDefaultPresets } from "./presets";
 
 export function resolveEffectPasses({
 	definition,
 	effectParams,
 	width,
 	height,
+	time,
+	context,
 }: {
 	definition: EffectDefinition;
 	effectParams: ParamValues;
 	width: number;
 	height: number;
+	time?: number;
+	context?: EffectContext;
 }): ResolvedEffectPass[] {
 	if (definition.renderer.buildPasses) {
 		return definition.renderer.buildPasses({ effectParams, width, height });
 	}
 	return definition.renderer.passes.map((pass) => ({
 		fragmentShader: pass.fragmentShader,
-		uniforms: pass.uniforms({ effectParams, width, height }),
+		uniforms: pass.uniforms({ effectParams, width, height, time, context }),
 	}));
 }
 

--- a/apps/web/src/lib/effects/presets/beauty-presets.ts
+++ b/apps/web/src/lib/effects/presets/beauty-presets.ts
@@ -1,0 +1,30 @@
+import type { EffectPreset } from "./types";
+
+export const beautyPresets: EffectPreset[] = [
+	{
+		type: "soft-glow",
+		name: "Soft Glow",
+		category: "beauty",
+		description: "Dreamy soft-focus with gentle warmth",
+		effects: [
+			{ effectType: "brightness", params: { intensity: 5 } },
+			{ effectType: "contrast", params: { intensity: -5 } },
+			{ effectType: "saturation", params: { intensity: 10 } },
+			{ effectType: "blur", params: { intensity: 3 } },
+		],
+	},
+	{
+		type: "portrait",
+		name: "Portrait",
+		category: "beauty",
+		description: "Flattering portrait enhancement",
+		effects: [
+			{ effectType: "brightness", params: { intensity: 5 } },
+			{ effectType: "saturation", params: { intensity: 10 } },
+			{
+				effectType: "vignette",
+				params: { intensity: 20, radius: 85, softness: 60 },
+			},
+		],
+	},
+];

--- a/apps/web/src/lib/effects/presets/cinematic-presets.ts
+++ b/apps/web/src/lib/effects/presets/cinematic-presets.ts
@@ -1,0 +1,70 @@
+import type { EffectPreset } from "./types";
+
+export const cinematicPresets: EffectPreset[] = [
+	{
+		type: "teal-and-orange",
+		name: "Teal & Orange",
+		category: "cinematic",
+		description: "Classic Hollywood color grading",
+		effects: [
+			{
+				effectType: "color-balance",
+				params: {
+					shadowsRed: -30,
+					shadowsGreen: 10,
+					shadowsBlue: 30,
+					midtonesRed: 0,
+					midtonesGreen: 0,
+					midtonesBlue: 0,
+					highlightsRed: 30,
+					highlightsGreen: 10,
+					highlightsBlue: -20,
+				},
+			},
+			{ effectType: "contrast", params: { intensity: 15 } },
+		],
+	},
+	{
+		type: "vintage-film",
+		name: "Vintage Film",
+		category: "cinematic",
+		description: "Aged film stock with grain and warmth",
+		effects: [
+			{ effectType: "temperature", params: { warmth: 10 } },
+			{ effectType: "saturation", params: { intensity: -20 } },
+			{
+				effectType: "film-grain",
+				params: { intensity: 20, size: 2, animated: true },
+			},
+			{
+				effectType: "vignette",
+				params: { intensity: 30, radius: 75, softness: 50 },
+			},
+		],
+	},
+	{
+		type: "noir",
+		name: "Noir",
+		category: "cinematic",
+		description: "High contrast black and white",
+		effects: [
+			{ effectType: "saturation", params: { intensity: -100 } },
+			{ effectType: "contrast", params: { intensity: 30 } },
+			{
+				effectType: "vignette",
+				params: { intensity: 50, radius: 70, softness: 40 },
+			},
+		],
+	},
+	{
+		type: "bleach-bypass",
+		name: "Bleach Bypass",
+		category: "cinematic",
+		description: "Desaturated, high-contrast silver look",
+		effects: [
+			{ effectType: "saturation", params: { intensity: -40 } },
+			{ effectType: "contrast", params: { intensity: 25 } },
+			{ effectType: "brightness", params: { intensity: -5 } },
+		],
+	},
+];

--- a/apps/web/src/lib/effects/presets/index.ts
+++ b/apps/web/src/lib/effects/presets/index.ts
@@ -1,0 +1,30 @@
+export type { EffectPreset, EffectPresetEntry, PresetCategory } from "./types";
+export {
+	registerPreset,
+	getPreset,
+	hasPreset,
+	getAllPresets,
+	getPresetsByCategory,
+	clearPresets,
+} from "./registry";
+
+import { registerPreset, hasPreset } from "./registry";
+import { instagramPresets } from "./instagram-filters";
+import { cinematicPresets } from "./cinematic-presets";
+import { beautyPresets } from "./beauty-presets";
+
+/** All bundled presets */
+const allPresets = [...instagramPresets, ...cinematicPresets, ...beautyPresets];
+
+/** Register all bundled presets (skips already-registered) */
+export function registerDefaultPresets(): void {
+	for (const preset of allPresets) {
+		if (hasPreset(preset.type)) continue;
+		registerPreset(preset);
+	}
+}
+
+/** Get all bundled presets without registering */
+export function getAllBundledPresets(): typeof allPresets {
+	return [...allPresets];
+}

--- a/apps/web/src/lib/effects/presets/instagram-filters.ts
+++ b/apps/web/src/lib/effects/presets/instagram-filters.ts
@@ -1,0 +1,85 @@
+import type { EffectPreset } from "./types";
+
+export const instagramPresets: EffectPreset[] = [
+	{
+		type: "clarendon",
+		name: "Clarendon",
+		category: "instagram",
+		description: "Bright, vivid colors with strong contrast",
+		effects: [
+			{ effectType: "brightness", params: { intensity: 10 } },
+			{ effectType: "contrast", params: { intensity: 20 } },
+			{ effectType: "saturation", params: { intensity: 15 } },
+			{
+				effectType: "vignette",
+				params: { intensity: 30, radius: 80, softness: 50 },
+			},
+		],
+	},
+	{
+		type: "juno",
+		name: "Juno",
+		category: "instagram",
+		description: "Warm tones with boosted saturation",
+		effects: [
+			{ effectType: "brightness", params: { intensity: 5 } },
+			{ effectType: "saturation", params: { intensity: 25 } },
+			{ effectType: "temperature", params: { warmth: 15 } },
+			{
+				effectType: "vignette",
+				params: { intensity: 20, radius: 80, softness: 50 },
+			},
+		],
+	},
+	{
+		type: "lark",
+		name: "Lark",
+		category: "instagram",
+		description: "Bright, airy with desaturated colors",
+		effects: [
+			{ effectType: "brightness", params: { intensity: 15 } },
+			{ effectType: "contrast", params: { intensity: -10 } },
+			{ effectType: "saturation", params: { intensity: -15 } },
+			{ effectType: "temperature", params: { warmth: -10 } },
+		],
+	},
+	{
+		type: "gingham",
+		name: "Gingham",
+		category: "instagram",
+		description: "Soft, vintage feel with muted colors",
+		effects: [
+			{ effectType: "brightness", params: { intensity: 5 } },
+			{ effectType: "contrast", params: { intensity: -10 } },
+			{ effectType: "saturation", params: { intensity: -30 } },
+			{ effectType: "hue-shift", params: { degrees: 5 } },
+		],
+	},
+	{
+		type: "valencia",
+		name: "Valencia",
+		category: "instagram",
+		description: "Warm, faded with golden tones",
+		effects: [
+			{ effectType: "temperature", params: { warmth: 20 } },
+			{ effectType: "contrast", params: { intensity: 10 } },
+			{ effectType: "saturation", params: { intensity: -10 } },
+			{
+				effectType: "vignette",
+				params: { intensity: 40, radius: 70, softness: 60 },
+			},
+		],
+	},
+	{
+		type: "nashville",
+		name: "Nashville",
+		category: "instagram",
+		description: "Warm, dreamy with purple undertones",
+		effects: [
+			{ effectType: "brightness", params: { intensity: 10 } },
+			{ effectType: "temperature", params: { warmth: 30 } },
+			{ effectType: "contrast", params: { intensity: 20 } },
+			{ effectType: "saturation", params: { intensity: -20 } },
+		],
+	},
+];

--- a/apps/web/src/lib/effects/presets/registry.ts
+++ b/apps/web/src/lib/effects/presets/registry.ts
@@ -1,0 +1,29 @@
+import type { EffectPreset, PresetCategory } from "./types";
+
+const presetMap = new Map<string, EffectPreset>();
+
+export function registerPreset(preset: EffectPreset): void {
+	presetMap.set(preset.type, preset);
+}
+
+export function getPreset(type: string): EffectPreset {
+	const preset = presetMap.get(type);
+	if (!preset) throw new Error(`Unknown preset: ${type}`);
+	return preset;
+}
+
+export function hasPreset(type: string): boolean {
+	return presetMap.has(type);
+}
+
+export function getAllPresets(): EffectPreset[] {
+	return Array.from(presetMap.values());
+}
+
+export function getPresetsByCategory(category: PresetCategory): EffectPreset[] {
+	return getAllPresets().filter((preset) => preset.category === category);
+}
+
+export function clearPresets(): void {
+	presetMap.clear();
+}

--- a/apps/web/src/lib/effects/presets/types.ts
+++ b/apps/web/src/lib/effects/presets/types.ts
@@ -1,0 +1,17 @@
+/** A single effect entry within a preset */
+export interface EffectPresetEntry {
+	/** Must match a registered effect type (e.g., "brightness") */
+	effectType: string;
+	params: Record<string, number | string | boolean>;
+}
+
+export type PresetCategory = "instagram" | "cinematic" | "beauty" | "custom";
+
+/** Curated combination of effects with preset parameter values */
+export interface EffectPreset {
+	type: string;
+	name: string;
+	category: PresetCategory;
+	description: string;
+	effects: EffectPresetEntry[];
+}

--- a/apps/web/src/lib/effects/types.ts
+++ b/apps/web/src/lib/effects/types.ts
@@ -1,4 +1,5 @@
 import type { ParamDefinition, ParamValues } from "@/lib/params";
+import type { EffectCategory } from "@/lib/effects/categories";
 
 export interface Effect {
 	id: string;
@@ -12,12 +13,40 @@ export interface ResolvedEffectPass {
 	uniforms: Record<string, number | number[]>;
 }
 
+/**
+ * Face landmark / mask data for face-aware beauty effects.
+ * Populated by the renderer (via the face-mesh service) when a
+ * beauty-category effect is active.
+ */
+export interface EffectContext {
+	/** Face region mask as a flat array (0 = outside, 1 = face) */
+	faceMask?: number[];
+	/** Eye region mask */
+	eyeMask?: number[];
+	/** Mouth region mask */
+	mouthMask?: number[];
+	/** Left cheek center position [x, y] normalized 0..1 */
+	cheekLeft?: number[];
+	/** Right cheek center position [x, y] normalized 0..1 */
+	cheekRight?: number[];
+	/** Cheek radius normalized 0..1 */
+	cheekRadius?: number;
+	/** Jawline control points [x1,y1, x2,y2, ...] normalized 0..1 */
+	jawPoints?: number[];
+	/** Whether a face was detected in the current frame */
+	faceDetected?: boolean;
+}
+
 export interface WebGLEffectPass {
 	fragmentShader: string;
 	uniforms(params: {
 		effectParams: ParamValues;
 		width: number;
 		height: number;
+		/** Current playback time in seconds — for animated effects (film grain, glitch) */
+		time?: number;
+		/** Face landmark data for beauty effects — populated by renderer */
+		context?: EffectContext;
 	}): Record<string, number | number[]>;
 }
 
@@ -36,6 +65,7 @@ export type EffectRenderer = WebGLEffectRenderer;
 export interface EffectDefinition {
 	type: string;
 	name: string;
+	category?: EffectCategory;
 	keywords: string[];
 	params: ParamDefinition[];
 	renderer: EffectRenderer;

--- a/apps/web/src/lib/effects/utils/color.ts
+++ b/apps/web/src/lib/effects/utils/color.ts
@@ -1,0 +1,25 @@
+const HEX_COLOR_REGEX = /^#?([0-9A-Fa-f]{6}|[0-9A-Fa-f]{3})$/;
+const DEFAULT_RGB: [number, number, number] = [0, 1, 0.533]; // #00ff88
+
+/** Convert hex color string (#RRGGBB or #RGB) to normalized RGB array [0..1, 0..1, 0..1] */
+export function hexToRgb(hex: string): [number, number, number] {
+	if (!hex || !HEX_COLOR_REGEX.test(hex)) {
+		return DEFAULT_RGB;
+	}
+	let hexString = hex.replace("#", "");
+	// Expand shorthand (#RGB -> #RRGGBB)
+	if (hexString.length === 3) {
+		hexString =
+			hexString[0] +
+			hexString[0] +
+			hexString[1] +
+			hexString[1] +
+			hexString[2] +
+			hexString[2];
+	}
+	return [
+		Number.parseInt(hexString.slice(0, 2), 16) / 255,
+		Number.parseInt(hexString.slice(2, 4), 16) / 255,
+		Number.parseInt(hexString.slice(4, 6), 16) / 255,
+	];
+}

--- a/apps/web/src/lib/effects/utils/params.ts
+++ b/apps/web/src/lib/effects/utils/params.ts
@@ -1,0 +1,52 @@
+import type { ParamValues } from "@/lib/params";
+
+/**
+ * Type-safe parameter getters for effect uniforms.
+ * These eliminate the need for `as number` / `as string` casts throughout effect definitions.
+ */
+
+/** Get a number parameter with fallback default */
+export function getNumberParam(
+	params: ParamValues,
+	key: string,
+	defaultValue = 0,
+): number {
+	const value = params[key];
+	if (typeof value === "number") {
+		return value;
+	}
+	if (typeof value === "string") {
+		const parsed = Number.parseFloat(value);
+		return Number.isFinite(parsed) ? parsed : defaultValue;
+	}
+	return defaultValue;
+}
+
+/** Get a string parameter with fallback default */
+export function getStringParam(
+	params: ParamValues,
+	key: string,
+	defaultValue = "",
+): string {
+	const value = params[key];
+	if (typeof value === "string") {
+		return value;
+	}
+	if (typeof value === "number" || typeof value === "boolean") {
+		return String(value);
+	}
+	return defaultValue;
+}
+
+/** Get a boolean parameter with fallback default */
+export function getBooleanParam(
+	params: ParamValues,
+	key: string,
+	defaultValue = false,
+): boolean {
+	const value = params[key];
+	if (typeof value === "boolean") {
+		return value;
+	}
+	return defaultValue;
+}

--- a/apps/web/src/lib/timeline/element-utils.ts
+++ b/apps/web/src/lib/timeline/element-utils.ts
@@ -2,6 +2,7 @@ import { TIMELINE_CONSTANTS } from "@/constants/timeline-constants";
 import {
 	MASKABLE_ELEMENT_TYPES,
 	RETIMABLE_ELEMENT_TYPES,
+	TRANSFORMABLE_ELEMENT_TYPES,
 	VISUAL_ELEMENT_TYPES,
 	type CreateEffectElement,
 	type CreateGraphicElement,
@@ -20,6 +21,7 @@ import {
 	type ImageElement,
 	type MaskableElement,
 	type RetimableElement,
+	type TransformableElement,
 	type VisualElement,
 	type UploadAudioElement,
 } from "@/lib/timeline";
@@ -52,6 +54,14 @@ export function isRetimableElement(
 	element: TimelineElement,
 ): element is RetimableElement {
 	return (RETIMABLE_ELEMENT_TYPES as readonly string[]).includes(element.type);
+}
+
+export function isTransformableElement(
+	element: TimelineElement,
+): element is TransformableElement {
+	return (TRANSFORMABLE_ELEMENT_TYPES as readonly string[]).includes(
+		element.type,
+	);
 }
 
 export function canElementBeHidden(

--- a/apps/web/src/lib/timeline/types.ts
+++ b/apps/web/src/lib/timeline/types.ts
@@ -1,6 +1,7 @@
 import type { ElementAnimations } from "@/lib/animation/types";
 import type { Effect } from "@/lib/effects/types";
 import type { Mask } from "@/lib/masks/types";
+import type { ClipTransform } from "@/lib/transforms/types";
 import type { ParamValues } from "@/lib/params";
 import type { BlendMode, Transform } from "@/lib/rendering";
 
@@ -120,6 +121,7 @@ export interface VideoElement extends BaseTimelineElement {
 	blendMode?: BlendMode;
 	effects?: Effect[];
 	masks?: Mask[];
+	clipTransforms?: ClipTransform[];
 }
 
 export interface ImageElement extends BaseTimelineElement {
@@ -131,6 +133,7 @@ export interface ImageElement extends BaseTimelineElement {
 	blendMode?: BlendMode;
 	effects?: Effect[];
 	masks?: Mask[];
+	clipTransforms?: ClipTransform[];
 }
 
 export interface TextBackground {
@@ -174,6 +177,7 @@ export interface StickerElement extends BaseTimelineElement {
 	opacity: number;
 	blendMode?: BlendMode;
 	effects?: Effect[];
+	clipTransforms?: ClipTransform[];
 }
 
 export interface GraphicElement extends BaseTimelineElement {
@@ -186,6 +190,7 @@ export interface GraphicElement extends BaseTimelineElement {
 	blendMode?: BlendMode;
 	effects?: Effect[];
 	masks?: Mask[];
+	clipTransforms?: ClipTransform[];
 }
 
 export interface EffectElement extends BaseTimelineElement {
@@ -219,6 +224,23 @@ export const MASKABLE_ELEMENT_TYPES = elementTypes("video", "image", "graphic");
 export type MaskableElement = Extract<
 	TimelineElement,
 	{ type: (typeof MASKABLE_ELEMENT_TYPES)[number] }
+>;
+
+/**
+ * Element types that support clip transforms (spatial/visual). Excludes
+ * "text" — TextNode renders independently of VisualNode.renderVisual and
+ * does not consume clipTransforms.
+ */
+export const TRANSFORMABLE_ELEMENT_TYPES = elementTypes(
+	"video",
+	"image",
+	"sticker",
+	"graphic",
+);
+
+export type TransformableElement = Extract<
+	TimelineElement,
+	{ type: (typeof TRANSFORMABLE_ELEMENT_TYPES)[number] }
 >;
 
 export const RETIMABLE_ELEMENT_TYPES = elementTypes("video", "audio");

--- a/apps/web/src/lib/transforms/categories.ts
+++ b/apps/web/src/lib/transforms/categories.ts
@@ -1,0 +1,33 @@
+/** Transform categories for UI grouping */
+export const TransformCategory = {
+	SPATIAL: "spatial",
+	VISUAL: "visual",
+	TRANSITION: "transition",
+} as const;
+
+export type TransformCategory =
+	(typeof TransformCategory)[keyof typeof TransformCategory];
+
+export interface TransformCategoryMeta {
+	label: string;
+	description: string;
+}
+
+/** Display metadata for each transform category */
+export const TRANSFORM_CATEGORY_META: Record<
+	TransformCategory,
+	TransformCategoryMeta
+> = {
+	[TransformCategory.SPATIAL]: {
+		label: "Spatial",
+		description: "Scale, rotate, translate, flip, and crop transforms",
+	},
+	[TransformCategory.VISUAL]: {
+		label: "Visual",
+		description: "Lens distortion, perspective, and warp effects",
+	},
+	[TransformCategory.TRANSITION]: {
+		label: "Transitions",
+		description: "Clip-to-clip transitions like fade, wipe, and slide",
+	},
+};

--- a/apps/web/src/lib/transforms/definitions/index.ts
+++ b/apps/web/src/lib/transforms/definitions/index.ts
@@ -1,0 +1,42 @@
+import { transformsRegistry } from "@/lib/transforms/registry";
+import { scaleTransformDefinition } from "./spatial/scale";
+import { rotateTransformDefinition } from "./spatial/rotate";
+import { translateTransformDefinition } from "./spatial/translate";
+import { flipTransformDefinition } from "./spatial/flip";
+import { cropTransformDefinition } from "./spatial/crop";
+import { lensDistortionTransformDefinition } from "./visual/lens-distortion";
+import { perspectiveTransformDefinition } from "./visual/perspective";
+import { waveTransformDefinition } from "./visual/wave";
+import { fadeTransitionDefinition } from "./transitions/fade";
+import { wipeTransitionDefinition } from "./transitions/wipe";
+import { slideTransitionDefinition } from "./transitions/slide";
+import { zoomTransitionDefinition } from "./transitions/zoom";
+
+const defaultTransforms = [
+	// Spatial (Canvas2D matrix ops)
+	scaleTransformDefinition,
+	rotateTransformDefinition,
+	translateTransformDefinition,
+	flipTransformDefinition,
+	cropTransformDefinition,
+	// Visual (single-pass WebGL)
+	lensDistortionTransformDefinition,
+	perspectiveTransformDefinition,
+	waveTransformDefinition,
+	// Transitions — registered for completeness; NOT wired into the
+	// per-clip render pipeline (dual-source clip-to-clip compositing is
+	// out of scope for visual-node.ts). See types.ts TransitionRenderer doc.
+	fadeTransitionDefinition,
+	wipeTransitionDefinition,
+	slideTransitionDefinition,
+	zoomTransitionDefinition,
+];
+
+export function registerDefaultTransforms(): void {
+	for (const definition of defaultTransforms) {
+		if (transformsRegistry.has(definition.type)) {
+			continue;
+		}
+		transformsRegistry.register(definition.type, definition);
+	}
+}

--- a/apps/web/src/lib/transforms/definitions/spatial/crop.ts
+++ b/apps/web/src/lib/transforms/definitions/spatial/crop.ts
@@ -1,0 +1,75 @@
+import type { TransformDefinition } from "@/lib/transforms/types";
+import { TransformCategory } from "@/lib/transforms/categories";
+
+function paramNumber(
+	params: Record<string, unknown>,
+	key: string,
+	fallback: number,
+): number {
+	const value = params[key];
+	return typeof value === "number" ? value : fallback;
+}
+
+export const cropTransformDefinition: TransformDefinition = {
+	type: "crop",
+	name: "Crop",
+	category: TransformCategory.SPATIAL,
+	keywords: ["crop", "trim", "letterbox", "cut"],
+	params: [
+		{
+			key: "left",
+			label: "Left",
+			type: "number",
+			default: 0,
+			min: 0,
+			max: 50,
+			step: 1,
+		},
+		{
+			key: "right",
+			label: "Right",
+			type: "number",
+			default: 0,
+			min: 0,
+			max: 50,
+			step: 1,
+		},
+		{
+			key: "top",
+			label: "Top",
+			type: "number",
+			default: 0,
+			min: 0,
+			max: 50,
+			step: 1,
+		},
+		{
+			key: "bottom",
+			label: "Bottom",
+			type: "number",
+			default: 0,
+			min: 0,
+			max: 50,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "spatial",
+		apply({ ctx, transformParams, width, height }) {
+			const left = paramNumber(transformParams, "left", 0) / 100;
+			const right = paramNumber(transformParams, "right", 0) / 100;
+			const top = paramNumber(transformParams, "top", 0) / 100;
+			const bottom = paramNumber(transformParams, "bottom", 0) / 100;
+
+			const cropX = width * left;
+			const cropY = height * top;
+			const cropWidth = width * (1 - left - right);
+			const cropHeight = height * (1 - top - bottom);
+
+			// Create clipping region
+			ctx.beginPath();
+			ctx.rect(cropX, cropY, cropWidth, cropHeight);
+			ctx.clip();
+		},
+	},
+};

--- a/apps/web/src/lib/transforms/definitions/spatial/flip.ts
+++ b/apps/web/src/lib/transforms/definitions/spatial/flip.ts
@@ -1,0 +1,36 @@
+import type { TransformDefinition } from "@/lib/transforms/types";
+import { TransformCategory } from "@/lib/transforms/categories";
+
+export const flipTransformDefinition: TransformDefinition = {
+	type: "flip",
+	name: "Flip",
+	category: TransformCategory.SPATIAL,
+	keywords: ["flip", "mirror", "horizontal", "vertical"],
+	params: [
+		{
+			key: "horizontal",
+			label: "Horizontal",
+			type: "boolean",
+			default: false,
+		},
+		{
+			key: "vertical",
+			label: "Vertical",
+			type: "boolean",
+			default: false,
+		},
+	],
+	renderer: {
+		type: "spatial",
+		apply({ ctx, transformParams, width, height }) {
+			const horizontal = transformParams.horizontal === true;
+			const vertical = transformParams.vertical === true;
+
+			const scaleX = horizontal ? -1 : 1;
+			const scaleY = vertical ? -1 : 1;
+
+			ctx.translate(horizontal ? width : 0, vertical ? height : 0);
+			ctx.scale(scaleX, scaleY);
+		},
+	},
+};

--- a/apps/web/src/lib/transforms/definitions/spatial/rotate.ts
+++ b/apps/web/src/lib/transforms/definitions/spatial/rotate.ts
@@ -1,0 +1,63 @@
+import type { TransformDefinition } from "@/lib/transforms/types";
+import { TransformCategory } from "@/lib/transforms/categories";
+
+function paramNumber(
+	params: Record<string, unknown>,
+	key: string,
+	fallback: number,
+): number {
+	const value = params[key];
+	return typeof value === "number" ? value : fallback;
+}
+
+export const rotateTransformDefinition: TransformDefinition = {
+	type: "rotate",
+	name: "Rotate",
+	category: TransformCategory.SPATIAL,
+	keywords: ["rotate", "rotation", "spin", "angle"],
+	params: [
+		{
+			key: "angle",
+			label: "Angle",
+			type: "number",
+			default: 0,
+			min: -360,
+			max: 360,
+			step: 1,
+		},
+		{
+			key: "anchorX",
+			label: "Anchor X",
+			type: "number",
+			default: 50,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "anchorY",
+			label: "Anchor Y",
+			type: "number",
+			default: 50,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "spatial",
+		apply({ ctx, transformParams, width, height }) {
+			const angle = paramNumber(transformParams, "angle", 0);
+			const anchorX = paramNumber(transformParams, "anchorX", 50) / 100;
+			const anchorY = paramNumber(transformParams, "anchorY", 50) / 100;
+
+			const pivotX = width * anchorX;
+			const pivotY = height * anchorY;
+			const radians = (angle * Math.PI) / 180;
+
+			ctx.translate(pivotX, pivotY);
+			ctx.rotate(radians);
+			ctx.translate(-pivotX, -pivotY);
+		},
+	},
+};

--- a/apps/web/src/lib/transforms/definitions/spatial/scale.ts
+++ b/apps/web/src/lib/transforms/definitions/spatial/scale.ts
@@ -1,0 +1,72 @@
+import type { TransformDefinition } from "@/lib/transforms/types";
+import { TransformCategory } from "@/lib/transforms/categories";
+
+function paramNumber(
+	params: Record<string, unknown>,
+	key: string,
+	fallback: number,
+): number {
+	const value = params[key];
+	return typeof value === "number" ? value : fallback;
+}
+
+export const scaleTransformDefinition: TransformDefinition = {
+	type: "scale",
+	name: "Scale",
+	category: TransformCategory.SPATIAL,
+	keywords: ["scale", "zoom", "resize", "size"],
+	params: [
+		{
+			key: "scaleX",
+			label: "Scale X",
+			type: "number",
+			default: 100,
+			min: 0,
+			max: 500,
+			step: 1,
+		},
+		{
+			key: "scaleY",
+			label: "Scale Y",
+			type: "number",
+			default: 100,
+			min: 0,
+			max: 500,
+			step: 1,
+		},
+		{
+			key: "anchorX",
+			label: "Anchor X",
+			type: "number",
+			default: 50,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "anchorY",
+			label: "Anchor Y",
+			type: "number",
+			default: 50,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "spatial",
+		apply({ ctx, transformParams, width, height }) {
+			const scaleX = paramNumber(transformParams, "scaleX", 100) / 100;
+			const scaleY = paramNumber(transformParams, "scaleY", 100) / 100;
+			const anchorX = paramNumber(transformParams, "anchorX", 50) / 100;
+			const anchorY = paramNumber(transformParams, "anchorY", 50) / 100;
+
+			const pivotX = width * anchorX;
+			const pivotY = height * anchorY;
+
+			ctx.translate(pivotX, pivotY);
+			ctx.scale(scaleX, scaleY);
+			ctx.translate(-pivotX, -pivotY);
+		},
+	},
+};

--- a/apps/web/src/lib/transforms/definitions/spatial/translate.ts
+++ b/apps/web/src/lib/transforms/definitions/spatial/translate.ts
@@ -1,0 +1,51 @@
+import type { TransformDefinition } from "@/lib/transforms/types";
+import { TransformCategory } from "@/lib/transforms/categories";
+
+function paramNumber(
+	params: Record<string, unknown>,
+	key: string,
+	fallback: number,
+): number {
+	const value = params[key];
+	return typeof value === "number" ? value : fallback;
+}
+
+export const translateTransformDefinition: TransformDefinition = {
+	type: "translate",
+	name: "Translate",
+	category: TransformCategory.SPATIAL,
+	keywords: ["translate", "pan", "move", "position", "offset"],
+	params: [
+		{
+			key: "x",
+			label: "X Offset",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "y",
+			label: "Y Offset",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "spatial",
+		apply({ ctx, transformParams, width, height }) {
+			// Values are percentage of canvas size
+			const x = paramNumber(transformParams, "x", 0);
+			const y = paramNumber(transformParams, "y", 0);
+
+			const offsetX = (x / 100) * width;
+			const offsetY = (y / 100) * height;
+
+			ctx.translate(offsetX, offsetY);
+		},
+	},
+};

--- a/apps/web/src/lib/transforms/definitions/transitions/fade.frag.glsl
+++ b/apps/web/src/lib/transforms/definitions/transitions/fade.frag.glsl
@@ -1,0 +1,11 @@
+precision mediump float;
+uniform sampler2D u_textureA;
+uniform sampler2D u_textureB;
+uniform float u_progress;
+varying vec2 v_texCoord;
+
+void main() {
+    vec4 colorA = texture2D(u_textureA, v_texCoord);
+    vec4 colorB = texture2D(u_textureB, v_texCoord);
+    gl_FragColor = mix(colorA, colorB, u_progress);
+}

--- a/apps/web/src/lib/transforms/definitions/transitions/fade.ts
+++ b/apps/web/src/lib/transforms/definitions/transitions/fade.ts
@@ -1,0 +1,18 @@
+import type { TransformDefinition } from "@/lib/transforms/types";
+import { TransformCategory } from "@/lib/transforms/categories";
+import fragmentShader from "./fade.frag.glsl";
+
+export const fadeTransitionDefinition: TransformDefinition = {
+	type: "fade",
+	name: "Cross Dissolve",
+	category: TransformCategory.TRANSITION,
+	keywords: ["fade", "dissolve", "crossfade", "blend"],
+	params: [],
+	renderer: {
+		type: "transition",
+		fragmentShader,
+		uniforms({ progress }) {
+			return { u_progress: progress };
+		},
+	},
+};

--- a/apps/web/src/lib/transforms/definitions/transitions/slide.frag.glsl
+++ b/apps/web/src/lib/transforms/definitions/transitions/slide.frag.glsl
@@ -1,0 +1,42 @@
+precision mediump float;
+uniform sampler2D u_textureA;
+uniform sampler2D u_textureB;
+uniform float u_progress;
+uniform int u_direction; // 0=left, 1=right, 2=up, 3=down
+varying vec2 v_texCoord;
+
+void main() {
+    vec2 uvA = v_texCoord;
+    vec2 uvB = v_texCoord;
+
+    if (u_direction == 0) {
+        uvA.x += u_progress;
+        uvB.x += u_progress - 1.0;
+    } else if (u_direction == 1) {
+        uvA.x -= u_progress;
+        uvB.x -= u_progress - 1.0;
+    } else if (u_direction == 2) {
+        uvA.y -= u_progress;
+        uvB.y -= u_progress - 1.0;
+    } else {
+        uvA.y += u_progress;
+        uvB.y += u_progress - 1.0;
+    }
+
+    vec4 colorA = texture2D(u_textureA, uvA);
+    vec4 colorB = texture2D(u_textureB, uvB);
+
+    // Show A if in bounds, otherwise B
+    bool inBoundsA = uvA.x >= 0.0 && uvA.x <= 1.0 && uvA.y >= 0.0 && uvA.y <= 1.0;
+    bool inBoundsB = uvB.x >= 0.0 && uvB.x <= 1.0 && uvB.y >= 0.0 && uvB.y <= 1.0;
+
+    if (inBoundsA && inBoundsB) {
+        gl_FragColor = mix(colorA, colorB, 0.5);
+    } else if (inBoundsA) {
+        gl_FragColor = colorA;
+    } else if (inBoundsB) {
+        gl_FragColor = colorB;
+    } else {
+        gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    }
+}

--- a/apps/web/src/lib/transforms/definitions/transitions/slide.ts
+++ b/apps/web/src/lib/transforms/definitions/transitions/slide.ts
@@ -1,0 +1,38 @@
+import type { TransformDefinition } from "@/lib/transforms/types";
+import { TransformCategory } from "@/lib/transforms/categories";
+import fragmentShader from "./slide.frag.glsl";
+
+const DIRECTIONS = [
+	{ value: "left", label: "Slide Left" },
+	{ value: "right", label: "Slide Right" },
+	{ value: "up", label: "Slide Up" },
+	{ value: "down", label: "Slide Down" },
+];
+
+export const slideTransitionDefinition: TransformDefinition = {
+	type: "slide",
+	name: "Slide",
+	category: TransformCategory.TRANSITION,
+	keywords: ["slide", "push", "move"],
+	params: [
+		{
+			key: "direction",
+			label: "Direction",
+			type: "select",
+			default: "left",
+			options: DIRECTIONS,
+		},
+	],
+	renderer: {
+		type: "transition",
+		fragmentShader,
+		uniforms({ progress, transformParams }) {
+			const direction = String(transformParams.direction ?? "left");
+			const dirIndex = DIRECTIONS.findIndex((d) => d.value === direction);
+			return {
+				u_progress: progress,
+				u_direction: dirIndex >= 0 ? dirIndex : 0,
+			};
+		},
+	},
+};

--- a/apps/web/src/lib/transforms/definitions/transitions/wipe.frag.glsl
+++ b/apps/web/src/lib/transforms/definitions/transitions/wipe.frag.glsl
@@ -1,0 +1,26 @@
+precision mediump float;
+uniform sampler2D u_textureA;
+uniform sampler2D u_textureB;
+uniform float u_progress;
+uniform int u_direction; // 0=left, 1=right, 2=up, 3=down
+uniform float u_softness;
+varying vec2 v_texCoord;
+
+void main() {
+    vec4 colorA = texture2D(u_textureA, v_texCoord);
+    vec4 colorB = texture2D(u_textureB, v_texCoord);
+
+    float edge;
+    if (u_direction == 0) {
+        edge = v_texCoord.x;
+    } else if (u_direction == 1) {
+        edge = 1.0 - v_texCoord.x;
+    } else if (u_direction == 2) {
+        edge = 1.0 - v_texCoord.y;
+    } else {
+        edge = v_texCoord.y;
+    }
+
+    float softEdge = smoothstep(u_progress - u_softness, u_progress + u_softness, edge);
+    gl_FragColor = mix(colorB, colorA, softEdge);
+}

--- a/apps/web/src/lib/transforms/definitions/transitions/wipe.ts
+++ b/apps/web/src/lib/transforms/definitions/transitions/wipe.ts
@@ -1,0 +1,52 @@
+import type { TransformDefinition } from "@/lib/transforms/types";
+import { TransformCategory } from "@/lib/transforms/categories";
+import fragmentShader from "./wipe.frag.glsl";
+
+const DIRECTIONS = [
+	{ value: "left", label: "Left to Right" },
+	{ value: "right", label: "Right to Left" },
+	{ value: "up", label: "Bottom to Top" },
+	{ value: "down", label: "Top to Bottom" },
+];
+
+export const wipeTransitionDefinition: TransformDefinition = {
+	type: "wipe",
+	name: "Wipe",
+	category: TransformCategory.TRANSITION,
+	keywords: ["wipe", "reveal", "slide", "push"],
+	params: [
+		{
+			key: "direction",
+			label: "Direction",
+			type: "select",
+			default: "left",
+			options: DIRECTIONS,
+		},
+		{
+			key: "softness",
+			label: "Softness",
+			type: "number",
+			default: 5,
+			min: 0,
+			max: 50,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "transition",
+		fragmentShader,
+		uniforms({ progress, transformParams }) {
+			const direction = String(transformParams.direction ?? "left");
+			const dirIndex = DIRECTIONS.findIndex((d) => d.value === direction);
+			const softness =
+				(typeof transformParams.softness === "number"
+					? transformParams.softness
+					: 5) / 100;
+			return {
+				u_progress: progress,
+				u_direction: dirIndex >= 0 ? dirIndex : 0,
+				u_softness: softness,
+			};
+		},
+	},
+};

--- a/apps/web/src/lib/transforms/definitions/transitions/zoom.frag.glsl
+++ b/apps/web/src/lib/transforms/definitions/transitions/zoom.frag.glsl
@@ -1,0 +1,22 @@
+precision mediump float;
+uniform sampler2D u_textureA;
+uniform sampler2D u_textureB;
+uniform float u_progress;
+uniform float u_zoomAmount;
+varying vec2 v_texCoord;
+
+void main() {
+    // Zoom out A, zoom in B
+    float scaleA = 1.0 + u_progress * u_zoomAmount;
+    float scaleB = 1.0 + (1.0 - u_progress) * u_zoomAmount;
+
+    vec2 centerA = (v_texCoord - 0.5) / scaleA + 0.5;
+    vec2 centerB = (v_texCoord - 0.5) * scaleB + 0.5;
+
+    vec4 colorA = texture2D(u_textureA, centerA);
+    vec4 colorB = texture2D(u_textureB, centerB);
+
+    // Fade based on progress
+    float fade = smoothstep(0.3, 0.7, u_progress);
+    gl_FragColor = mix(colorA, colorB, fade);
+}

--- a/apps/web/src/lib/transforms/definitions/transitions/zoom.ts
+++ b/apps/web/src/lib/transforms/definitions/transitions/zoom.ts
@@ -1,0 +1,35 @@
+import type { TransformDefinition } from "@/lib/transforms/types";
+import { TransformCategory } from "@/lib/transforms/categories";
+import fragmentShader from "./zoom.frag.glsl";
+
+export const zoomTransitionDefinition: TransformDefinition = {
+	type: "zoom",
+	name: "Zoom",
+	category: TransformCategory.TRANSITION,
+	keywords: ["zoom", "scale", "punch"],
+	params: [
+		{
+			key: "zoomAmount",
+			label: "Zoom Amount",
+			type: "number",
+			default: 20,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "transition",
+		fragmentShader,
+		uniforms({ progress, transformParams }) {
+			const zoomAmount =
+				(typeof transformParams.zoomAmount === "number"
+					? transformParams.zoomAmount
+					: 20) / 100;
+			return {
+				u_progress: progress,
+				u_zoomAmount: zoomAmount,
+			};
+		},
+	},
+};

--- a/apps/web/src/lib/transforms/definitions/visual/lens-distortion.frag.glsl
+++ b/apps/web/src/lib/transforms/definitions/visual/lens-distortion.frag.glsl
@@ -1,0 +1,25 @@
+precision mediump float;
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_strength;
+uniform float u_zoom;
+varying vec2 v_texCoord;
+
+void main() {
+    vec2 uv = v_texCoord;
+    vec2 center = vec2(0.5, 0.5);
+    vec2 delta = uv - center;
+    float dist = length(delta);
+
+    // Barrel/pincushion distortion
+    float distortion = 1.0 + dist * dist * u_strength;
+    vec2 distortedUV = center + delta * distortion * u_zoom;
+
+    // Clamp to valid UV range
+    if (distortedUV.x < 0.0 || distortedUV.x > 1.0 ||
+        distortedUV.y < 0.0 || distortedUV.y > 1.0) {
+        gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    } else {
+        gl_FragColor = texture2D(u_texture, distortedUV);
+    }
+}

--- a/apps/web/src/lib/transforms/definitions/visual/lens-distortion.ts
+++ b/apps/web/src/lib/transforms/definitions/visual/lens-distortion.ts
@@ -1,0 +1,51 @@
+import type { TransformDefinition } from "@/lib/transforms/types";
+import { TransformCategory } from "@/lib/transforms/categories";
+import fragmentShader from "./lens-distortion.frag.glsl";
+
+function paramNumber(
+	params: Record<string, unknown>,
+	key: string,
+	fallback: number,
+): number {
+	const value = params[key];
+	return typeof value === "number" ? value : fallback;
+}
+
+export const lensDistortionTransformDefinition: TransformDefinition = {
+	type: "lens-distortion",
+	name: "Lens Distortion",
+	category: TransformCategory.VISUAL,
+	keywords: ["lens", "distortion", "barrel", "pincushion", "fisheye"],
+	params: [
+		{
+			key: "strength",
+			label: "Strength",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "zoom",
+			label: "Zoom",
+			type: "number",
+			default: 100,
+			min: 50,
+			max: 150,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		fragmentShader,
+		uniforms({ transformParams }) {
+			const strength = paramNumber(transformParams, "strength", 0) / 100;
+			const zoom = paramNumber(transformParams, "zoom", 100) / 100;
+			return {
+				u_strength: strength,
+				u_zoom: zoom,
+			};
+		},
+	},
+};

--- a/apps/web/src/lib/transforms/definitions/visual/perspective.frag.glsl
+++ b/apps/web/src/lib/transforms/definitions/visual/perspective.frag.glsl
@@ -1,0 +1,22 @@
+precision mediump float;
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_rotateX;
+uniform float u_rotateY;
+uniform float u_perspective;
+varying vec2 v_texCoord;
+
+void main() {
+    vec2 uv = v_texCoord - 0.5;
+
+    // Simple perspective projection
+    float z = 1.0 + u_perspective * (uv.x * u_rotateY + uv.y * u_rotateX);
+    vec2 perspectiveUV = uv / z + 0.5;
+
+    if (perspectiveUV.x < 0.0 || perspectiveUV.x > 1.0 ||
+        perspectiveUV.y < 0.0 || perspectiveUV.y > 1.0) {
+        gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    } else {
+        gl_FragColor = texture2D(u_texture, perspectiveUV);
+    }
+}

--- a/apps/web/src/lib/transforms/definitions/visual/perspective.ts
+++ b/apps/web/src/lib/transforms/definitions/visual/perspective.ts
@@ -1,0 +1,59 @@
+import type { TransformDefinition } from "@/lib/transforms/types";
+import { TransformCategory } from "@/lib/transforms/categories";
+import fragmentShader from "./perspective.frag.glsl";
+
+function paramNumber(
+	params: Record<string, unknown>,
+	key: string,
+	fallback: number,
+): number {
+	const value = params[key];
+	return typeof value === "number" ? value : fallback;
+}
+
+export const perspectiveTransformDefinition: TransformDefinition = {
+	type: "perspective",
+	name: "Perspective",
+	category: TransformCategory.VISUAL,
+	keywords: ["perspective", "3d", "tilt", "warp"],
+	params: [
+		{
+			key: "rotateX",
+			label: "Tilt X",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "rotateY",
+			label: "Tilt Y",
+			type: "number",
+			default: 0,
+			min: -100,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "perspective",
+			label: "Depth",
+			type: "number",
+			default: 50,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		fragmentShader,
+		uniforms({ transformParams }) {
+			return {
+				u_rotateX: paramNumber(transformParams, "rotateX", 0) / 100,
+				u_rotateY: paramNumber(transformParams, "rotateY", 0) / 100,
+				u_perspective: paramNumber(transformParams, "perspective", 50) / 100,
+			};
+		},
+	},
+};

--- a/apps/web/src/lib/transforms/definitions/visual/wave.frag.glsl
+++ b/apps/web/src/lib/transforms/definitions/visual/wave.frag.glsl
@@ -1,0 +1,22 @@
+precision mediump float;
+uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_amplitude;
+uniform float u_frequency;
+uniform float u_speed;
+uniform float u_time;
+varying vec2 v_texCoord;
+
+void main() {
+    vec2 uv = v_texCoord;
+
+    // Animated wave distortion
+    float wave = sin(uv.y * u_frequency + u_time * u_speed) * u_amplitude;
+    uv.x += wave;
+
+    if (uv.x < 0.0 || uv.x > 1.0) {
+        gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    } else {
+        gl_FragColor = texture2D(u_texture, uv);
+    }
+}

--- a/apps/web/src/lib/transforms/definitions/visual/wave.ts
+++ b/apps/web/src/lib/transforms/definitions/visual/wave.ts
@@ -1,0 +1,60 @@
+import type { TransformDefinition } from "@/lib/transforms/types";
+import { TransformCategory } from "@/lib/transforms/categories";
+import fragmentShader from "./wave.frag.glsl";
+
+function paramNumber(
+	params: Record<string, unknown>,
+	key: string,
+	fallback: number,
+): number {
+	const value = params[key];
+	return typeof value === "number" ? value : fallback;
+}
+
+export const waveTransformDefinition: TransformDefinition = {
+	type: "wave",
+	name: "Wave",
+	category: TransformCategory.VISUAL,
+	keywords: ["wave", "ripple", "distort", "wobble"],
+	params: [
+		{
+			key: "amplitude",
+			label: "Amplitude",
+			type: "number",
+			default: 10,
+			min: 0,
+			max: 50,
+			step: 1,
+		},
+		{
+			key: "frequency",
+			label: "Frequency",
+			type: "number",
+			default: 10,
+			min: 1,
+			max: 50,
+			step: 1,
+		},
+		{
+			key: "speed",
+			label: "Speed",
+			type: "number",
+			default: 50,
+			min: 0,
+			max: 100,
+			step: 1,
+		},
+	],
+	renderer: {
+		type: "webgl",
+		fragmentShader,
+		uniforms({ transformParams, time }) {
+			return {
+				u_amplitude: paramNumber(transformParams, "amplitude", 10) / 100,
+				u_frequency: paramNumber(transformParams, "frequency", 10),
+				u_speed: paramNumber(transformParams, "speed", 50) / 10,
+				u_time: time ?? 0,
+			};
+		},
+	},
+};

--- a/apps/web/src/lib/transforms/index.ts
+++ b/apps/web/src/lib/transforms/index.ts
@@ -1,0 +1,28 @@
+import { generateUUID } from "@/utils/id";
+import { buildDefaultParamValues } from "@/lib/registry";
+import { transformsRegistry } from "./registry";
+import type { ParamValues } from "@/lib/params";
+import type { ClipTransform } from "@/lib/transforms/types";
+import { TRANSFORMABLE_ELEMENT_TYPES } from "@/lib/timeline";
+
+export { transformsRegistry } from "./registry";
+export { registerDefaultTransforms } from "./definitions";
+export { registerDefaultPresets } from "./presets";
+
+export const TRANSFORM_TARGET_ELEMENT_TYPES = TRANSFORMABLE_ELEMENT_TYPES;
+
+export function buildDefaultTransformInstance({
+	transformType,
+}: {
+	transformType: string;
+}): ClipTransform {
+	const definition = transformsRegistry.get(transformType);
+	const params: ParamValues = buildDefaultParamValues(definition.params);
+
+	return {
+		id: generateUUID(),
+		type: transformType,
+		params,
+		enabled: true,
+	};
+}

--- a/apps/web/src/lib/transforms/presets/__tests__/ken-burns-preset-animation.test.ts
+++ b/apps/web/src/lib/transforms/presets/__tests__/ken-burns-preset-animation.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import { registerDefaultTransforms } from "@/lib/transforms/definitions";
+import { registerDefaultPresets } from "@/lib/transforms/presets";
+import { applyPresetToElement } from "@/lib/commands/timeline/element/transforms/apply-preset-to-element";
+import { resolveTransformParamsAtTime } from "@/lib/animation/transform-param-channel";
+import type { ImageElement } from "@/lib/timeline";
+
+registerDefaultTransforms();
+registerDefaultPresets();
+
+const CLIP_DURATION = 5;
+
+function buildImageElement(): ImageElement {
+	return {
+		id: "element-1",
+		type: "image",
+		name: "Photo",
+		mediaId: "media-1",
+		duration: CLIP_DURATION,
+		startTime: 0,
+		trimStart: 0,
+		trimEnd: 0,
+		transform: { position: { x: 0, y: 0 }, scaleX: 1, scaleY: 1, rotate: 0 },
+		opacity: 1,
+	};
+}
+
+describe("Ken Burns preset animation", () => {
+	test("applying the preset creates a keyframed scale transform", () => {
+		const element = buildImageElement();
+
+		const { element: updated, transformIds } = applyPresetToElement({
+			element,
+			presetType: "ken-burns",
+		});
+
+		expect(transformIds.length).toBe(2);
+		expect(updated.clipTransforms?.length).toBe(2);
+
+		const scaleTransform = updated.clipTransforms?.find(
+			(transform) => transform.type === "scale",
+		);
+		expect(scaleTransform).toBeDefined();
+		expect(updated.animations).toBeDefined();
+
+		// Start of clip (localTime = 0) resolves to the preset's start
+		// keyframe value (scaleX/scaleY = 100).
+		const startParams = resolveTransformParamsAtTime({
+			// biome-ignore lint/style/noNonNullAssertion: asserted above
+			transform: scaleTransform!,
+			animations: updated.animations,
+			localTime: 0,
+		});
+		expect(startParams.scaleX).toBe(100);
+		expect(startParams.scaleY).toBe(100);
+
+		// End of clip (localTime = duration) resolves to the preset's end
+		// keyframe value (scaleX/scaleY = 130).
+		const endParams = resolveTransformParamsAtTime({
+			// biome-ignore lint/style/noNonNullAssertion: asserted above
+			transform: scaleTransform!,
+			animations: updated.animations,
+			localTime: CLIP_DURATION,
+		});
+		expect(endParams.scaleX).toBe(130);
+		expect(endParams.scaleY).toBe(130);
+
+		// Static (non-animated) params pass through unchanged.
+		expect(startParams.anchorX).toBe(30);
+		expect(endParams.anchorX).toBe(30);
+	});
+
+	test("applying the preset creates a keyframed translate transform", () => {
+		const element = buildImageElement();
+
+		const { element: updated } = applyPresetToElement({
+			element,
+			presetType: "ken-burns",
+		});
+
+		const translateTransform = updated.clipTransforms?.find(
+			(transform) => transform.type === "translate",
+		);
+		expect(translateTransform).toBeDefined();
+
+		const startParams = resolveTransformParamsAtTime({
+			// biome-ignore lint/style/noNonNullAssertion: asserted above
+			transform: translateTransform!,
+			animations: updated.animations,
+			localTime: 0,
+		});
+		expect(startParams.x).toBe(0);
+		expect(startParams.y).toBe(0);
+
+		const endParams = resolveTransformParamsAtTime({
+			// biome-ignore lint/style/noNonNullAssertion: asserted above
+			transform: translateTransform!,
+			animations: updated.animations,
+			localTime: CLIP_DURATION,
+		});
+		expect(endParams.x).toBe(-10);
+		expect(endParams.y).toBe(-5);
+	});
+
+	test("mid-clip time interpolates linearly between keyframes", () => {
+		const element = buildImageElement();
+
+		const { element: updated } = applyPresetToElement({
+			element,
+			presetType: "ken-burns",
+		});
+		const scaleTransform = updated.clipTransforms?.find(
+			(transform) => transform.type === "scale",
+		);
+
+		const midParams = resolveTransformParamsAtTime({
+			// biome-ignore lint/style/noNonNullAssertion: asserted above
+			transform: scaleTransform!,
+			animations: updated.animations,
+			localTime: CLIP_DURATION / 2,
+		});
+		// Linear interpolation halfway between 100 and 130.
+		expect(midParams.scaleX).toBe(115);
+		expect(midParams.scaleY).toBe(115);
+	});
+});

--- a/apps/web/src/lib/transforms/presets/cinematic-zoom.ts
+++ b/apps/web/src/lib/transforms/presets/cinematic-zoom.ts
@@ -1,0 +1,66 @@
+import type { TransformPreset } from "./types";
+
+/**
+ * Ported 1:1 from source package keyframe data. Source easing
+ * "ease-in-out-cubic" has no bezier equivalent in dev's animation system
+ * (linear/hold only) — mapped to "linear" when the preset is applied (see
+ * `apply-preset.ts`).
+ */
+export const cinematicZoomInPreset: TransformPreset = {
+	type: "cinematic-zoom-in",
+	name: "Cinematic Zoom In",
+	description: "Slow dramatic zoom toward center",
+	category: "cinematic",
+	suggestedDuration: 3,
+	transforms: [
+		{
+			transformType: "scale",
+			params: {
+				scaleX: 100,
+				scaleY: 100,
+				anchorX: 50,
+				anchorY: 50,
+			},
+			animatedParams: {
+				scaleX: [
+					{ normalizedTime: 0, value: 100, easing: "ease-in-out-cubic" },
+					{ normalizedTime: 1, value: 120 },
+				],
+				scaleY: [
+					{ normalizedTime: 0, value: 100, easing: "ease-in-out-cubic" },
+					{ normalizedTime: 1, value: 120 },
+				],
+			},
+		},
+	],
+};
+
+/** Smooth zoom out */
+export const cinematicZoomOutPreset: TransformPreset = {
+	type: "cinematic-zoom-out",
+	name: "Cinematic Zoom Out",
+	description: "Slow dramatic zoom away from center",
+	category: "cinematic",
+	suggestedDuration: 3,
+	transforms: [
+		{
+			transformType: "scale",
+			params: {
+				scaleX: 120,
+				scaleY: 120,
+				anchorX: 50,
+				anchorY: 50,
+			},
+			animatedParams: {
+				scaleX: [
+					{ normalizedTime: 0, value: 120, easing: "ease-in-out-cubic" },
+					{ normalizedTime: 1, value: 100 },
+				],
+				scaleY: [
+					{ normalizedTime: 0, value: 120, easing: "ease-in-out-cubic" },
+					{ normalizedTime: 1, value: 100 },
+				],
+			},
+		},
+	],
+};

--- a/apps/web/src/lib/transforms/presets/index.ts
+++ b/apps/web/src/lib/transforms/presets/index.ts
@@ -1,0 +1,44 @@
+export type {
+	TransformPreset,
+	TransformPresetEntry,
+	TransformPresetCategory,
+} from "./types";
+export {
+	registerPreset,
+	getPreset,
+	hasPreset,
+	getAllPresets,
+	getPresetsByCategory,
+	clearPresets,
+} from "./registry";
+
+import { registerPreset, hasPreset } from "./registry";
+import { kenBurnsPreset, kenBurnsReversePreset } from "./ken-burns";
+import {
+	cinematicZoomInPreset,
+	cinematicZoomOutPreset,
+} from "./cinematic-zoom";
+import { rotateRevealPreset, spinExitPreset } from "./rotate-reveal";
+
+/** All bundled transform presets */
+const allPresets = [
+	kenBurnsPreset,
+	kenBurnsReversePreset,
+	cinematicZoomInPreset,
+	cinematicZoomOutPreset,
+	rotateRevealPreset,
+	spinExitPreset,
+];
+
+/** Register all bundled transform presets (skips already-registered) */
+export function registerDefaultPresets(): void {
+	for (const preset of allPresets) {
+		if (hasPreset(preset.type)) continue;
+		registerPreset(preset);
+	}
+}
+
+/** Get all bundled transform presets without registering */
+export function getAllBundledPresets(): typeof allPresets {
+	return [...allPresets];
+}

--- a/apps/web/src/lib/transforms/presets/ken-burns.ts
+++ b/apps/web/src/lib/transforms/presets/ken-burns.ts
@@ -1,0 +1,85 @@
+import type { TransformPreset } from "./types";
+
+/**
+ * Ken Burns: Pan + zoom effect for photos. Ported 1:1 from the source
+ * package's keyframe data (scratchpad `packages/transforms/src/presets/
+ * ken-burns.ts`) — `animatedParams` normalized times (0..1) are converted
+ * to absolute seconds against the target clip's duration when the preset
+ * is applied (see `apply-preset.ts`). Static (non-animated) params like
+ * anchorX/anchorY stay in `params`.
+ */
+export const kenBurnsPreset: TransformPreset = {
+	type: "ken-burns",
+	name: "Ken Burns",
+	description: "Classic documentary-style pan and zoom for photos",
+	category: "motion",
+	suggestedDuration: 5,
+	transforms: [
+		{
+			transformType: "scale",
+			params: {
+				scaleX: 100,
+				scaleY: 100,
+				anchorX: 30,
+				anchorY: 30,
+			},
+			animatedParams: {
+				scaleX: [
+					{ normalizedTime: 0, value: 100, easing: "ease-out" },
+					{ normalizedTime: 1, value: 130 },
+				],
+				scaleY: [
+					{ normalizedTime: 0, value: 100, easing: "ease-out" },
+					{ normalizedTime: 1, value: 130 },
+				],
+			},
+		},
+		{
+			transformType: "translate",
+			params: {
+				x: 0,
+				y: 0,
+			},
+			animatedParams: {
+				x: [
+					{ normalizedTime: 0, value: 0, easing: "ease-in-out" },
+					{ normalizedTime: 1, value: -10 },
+				],
+				y: [
+					{ normalizedTime: 0, value: 0, easing: "ease-in-out" },
+					{ normalizedTime: 1, value: -5 },
+				],
+			},
+		},
+	],
+};
+
+/** Ken Burns reverse: zoom out */
+export const kenBurnsReversePreset: TransformPreset = {
+	type: "ken-burns-reverse",
+	name: "Ken Burns (Reverse)",
+	description: "Zoom out reveal effect for photos",
+	category: "motion",
+	suggestedDuration: 5,
+	transforms: [
+		{
+			transformType: "scale",
+			params: {
+				scaleX: 130,
+				scaleY: 130,
+				anchorX: 70,
+				anchorY: 70,
+			},
+			animatedParams: {
+				scaleX: [
+					{ normalizedTime: 0, value: 130, easing: "ease-out" },
+					{ normalizedTime: 1, value: 100 },
+				],
+				scaleY: [
+					{ normalizedTime: 0, value: 130, easing: "ease-out" },
+					{ normalizedTime: 1, value: 100 },
+				],
+			},
+		},
+	],
+};

--- a/apps/web/src/lib/transforms/presets/registry.ts
+++ b/apps/web/src/lib/transforms/presets/registry.ts
@@ -1,0 +1,31 @@
+import type { TransformPreset, TransformPresetCategory } from "./types";
+
+const presetMap = new Map<string, TransformPreset>();
+
+export function registerPreset(preset: TransformPreset): void {
+	presetMap.set(preset.type, preset);
+}
+
+export function getPreset(type: string): TransformPreset {
+	const preset = presetMap.get(type);
+	if (!preset) throw new Error(`Unknown transform preset: ${type}`);
+	return preset;
+}
+
+export function hasPreset(type: string): boolean {
+	return presetMap.has(type);
+}
+
+export function getAllPresets(): TransformPreset[] {
+	return Array.from(presetMap.values());
+}
+
+export function getPresetsByCategory(
+	category: TransformPresetCategory,
+): TransformPreset[] {
+	return getAllPresets().filter((preset) => preset.category === category);
+}
+
+export function clearPresets(): void {
+	presetMap.clear();
+}

--- a/apps/web/src/lib/transforms/presets/rotate-reveal.ts
+++ b/apps/web/src/lib/transforms/presets/rotate-reveal.ts
@@ -1,0 +1,94 @@
+import type { TransformPreset } from "./types";
+
+/**
+ * Ported 1:1 from source package keyframe data. Source easings
+ * "ease-out-cubic" / "ease-in-cubic" have no bezier equivalent in dev's
+ * animation system (linear/hold only) — mapped to "linear" when the
+ * preset is applied (see `apply-preset.ts`).
+ */
+export const rotateRevealPreset: TransformPreset = {
+	type: "rotate-reveal",
+	name: "Rotate Reveal",
+	description: "Rotation with scale for dramatic reveal",
+	category: "reveal",
+	suggestedDuration: 2,
+	transforms: [
+		{
+			transformType: "rotate",
+			params: {
+				angle: -15,
+				anchorX: 50,
+				anchorY: 50,
+			},
+			animatedParams: {
+				angle: [
+					{ normalizedTime: 0, value: -15, easing: "ease-out-cubic" },
+					{ normalizedTime: 1, value: 0 },
+				],
+			},
+		},
+		{
+			transformType: "scale",
+			params: {
+				scaleX: 80,
+				scaleY: 80,
+				anchorX: 50,
+				anchorY: 50,
+			},
+			animatedParams: {
+				scaleX: [
+					{ normalizedTime: 0, value: 80, easing: "ease-out-cubic" },
+					{ normalizedTime: 1, value: 100 },
+				],
+				scaleY: [
+					{ normalizedTime: 0, value: 80, easing: "ease-out-cubic" },
+					{ normalizedTime: 1, value: 100 },
+				],
+			},
+		},
+	],
+};
+
+/** Spin exit */
+export const spinExitPreset: TransformPreset = {
+	type: "spin-exit",
+	name: "Spin Exit",
+	description: "Rotate and scale down to exit",
+	category: "reveal",
+	suggestedDuration: 1,
+	transforms: [
+		{
+			transformType: "rotate",
+			params: {
+				angle: 0,
+				anchorX: 50,
+				anchorY: 50,
+			},
+			animatedParams: {
+				angle: [
+					{ normalizedTime: 0, value: 0, easing: "ease-in-cubic" },
+					{ normalizedTime: 1, value: 180 },
+				],
+			},
+		},
+		{
+			transformType: "scale",
+			params: {
+				scaleX: 100,
+				scaleY: 100,
+				anchorX: 50,
+				anchorY: 50,
+			},
+			animatedParams: {
+				scaleX: [
+					{ normalizedTime: 0, value: 100, easing: "ease-in-cubic" },
+					{ normalizedTime: 1, value: 0 },
+				],
+				scaleY: [
+					{ normalizedTime: 0, value: 100, easing: "ease-in-cubic" },
+					{ normalizedTime: 1, value: 0 },
+				],
+			},
+		},
+	],
+};

--- a/apps/web/src/lib/transforms/presets/types.ts
+++ b/apps/web/src/lib/transforms/presets/types.ts
@@ -1,0 +1,51 @@
+import type { ParamValues } from "@/lib/params";
+
+/**
+ * Single keyframe within a preset param animation. `normalizedTime` is
+ * 0..1 relative to the clip/element duration (ported from the source
+ * package's `Keyframe.time`, renamed here to avoid confusion with the
+ * absolute-seconds `time` used by dev's `@/lib/animation` channels).
+ * `easing` is carried through from the source data for documentation
+ * purposes only — dev's animation channels only support "linear" | "hold"
+ * interpolation, so all preset keyframes are applied as "linear" when
+ * converted to animation channels (see `apply-preset.ts`).
+ */
+export interface TransformPresetKeyframe {
+	normalizedTime: number;
+	value: number;
+	easing?: string;
+}
+
+/**
+ * A single transform entry within a preset. `params` holds the static
+ * (non-animated) param values used to construct the `ClipTransform`
+ * instance. `animatedParams` holds per-param keyframe arrays for params
+ * that should animate over the clip duration — applying the preset
+ * converts these into `@/lib/animation` channels at
+ * `clipTransforms.<transformId>.params.<paramKey>`
+ * (see `resolveTransformParamsAtTime` / `apply-preset.ts`).
+ */
+export interface TransformPresetEntry {
+	/** Must match a registered transform type (e.g., "scale") */
+	transformType: string;
+	params: ParamValues;
+	animatedParams?: Record<string, TransformPresetKeyframe[]>;
+}
+
+export type TransformPresetCategory = "motion" | "reveal" | "cinematic";
+
+/** Curated combination of transforms with preset parameter values */
+export interface TransformPreset {
+	type: string;
+	name: string;
+	category: TransformPresetCategory;
+	description: string;
+	/**
+	 * Duration hint in seconds (UI guidance only). Normalized keyframe
+	 * times in `animatedParams` are mapped to absolute seconds using the
+	 * TARGET clip's actual duration when the preset is applied, not this
+	 * suggestion.
+	 */
+	suggestedDuration?: number;
+	transforms: TransformPresetEntry[];
+}

--- a/apps/web/src/lib/transforms/registry.ts
+++ b/apps/web/src/lib/transforms/registry.ts
@@ -1,0 +1,13 @@
+import { DefinitionRegistry } from "@/lib/registry";
+import type { TransformDefinition } from "@/lib/transforms/types";
+
+export class TransformsRegistry extends DefinitionRegistry<
+	string,
+	TransformDefinition
+> {
+	constructor() {
+		super("transform");
+	}
+}
+
+export const transformsRegistry = new TransformsRegistry();

--- a/apps/web/src/lib/transforms/transform.vert.glsl
+++ b/apps/web/src/lib/transforms/transform.vert.glsl
@@ -1,0 +1,7 @@
+attribute vec2 a_position;
+varying vec2 v_texCoord;
+
+void main() {
+  v_texCoord = a_position * 0.5 + 0.5;
+  gl_Position = vec4(a_position, 0.0, 1.0);
+}

--- a/apps/web/src/lib/transforms/types.ts
+++ b/apps/web/src/lib/transforms/types.ts
@@ -1,0 +1,72 @@
+import type { ParamDefinition, ParamValues } from "@/lib/params";
+import type { TransformCategory } from "@/lib/transforms/categories";
+
+/**
+ * Transform instance attached to a timeline clip.
+ * Mirrors `Effect` from `@/lib/effects/types` — reuses the shared
+ * `@/lib/params` ParamValues shape instead of the standalone package's
+ * custom keyframe/point param system, since dev's animation system
+ * (`@/lib/animation`) already provides keyframing for any numeric param.
+ */
+export interface ClipTransform {
+	id: string;
+	type: string;
+	params: ParamValues;
+	enabled: boolean;
+}
+
+/** Spatial transform renderer — mutates a Canvas2D context (matrix ops). */
+export interface SpatialTransformRenderer {
+	type: "spatial";
+	apply(params: {
+		ctx: CanvasRenderingContext2D;
+		transformParams: ParamValues;
+		width: number;
+		height: number;
+	}): void;
+}
+
+/** Visual transform renderer — single-pass WebGL shader. */
+export interface VisualTransformRenderer {
+	type: "webgl";
+	fragmentShader: string;
+	uniforms(params: {
+		transformParams: ParamValues;
+		width: number;
+		height: number;
+		time?: number;
+	}): Record<string, number | number[]>;
+}
+
+/**
+ * Transition renderer — dual-source WebGL shader for clip-to-clip blends.
+ * Registered for completeness (parity with source package) but NOT wired
+ * into the per-clip render pipeline (`visual-node.ts`), which only
+ * composites a single source per element. Clip-to-clip transition
+ * compositing is a separate, larger scene-builder concern deferred to a
+ * future phase.
+ */
+export interface TransitionRenderer {
+	type: "transition";
+	fragmentShader: string;
+	uniforms(params: {
+		progress: number;
+		transformParams: ParamValues;
+		width: number;
+		height: number;
+	}): Record<string, number | number[]>;
+}
+
+export type TransformRenderer =
+	| SpatialTransformRenderer
+	| VisualTransformRenderer
+	| TransitionRenderer;
+
+export interface TransformDefinition {
+	type: string;
+	name: string;
+	category: TransformCategory;
+	keywords: string[];
+	params: ParamDefinition[];
+	renderer: TransformRenderer;
+}

--- a/apps/web/src/services/face-mesh/face-mesh-provider.ts
+++ b/apps/web/src/services/face-mesh/face-mesh-provider.ts
@@ -1,0 +1,241 @@
+import type { EffectContext } from "@/lib/effects/types";
+
+/**
+ * Face mesh detection provider using MediaPipe Face Mesh.
+ * Lazy-loads the WASM module only when first needed.
+ * Runs detection per frame and caches results.
+ */
+
+import type { FaceMesh as FaceMeshType, Results } from "@mediapipe/face_mesh";
+
+let faceMeshInstance: FaceMeshType | null = null;
+let isLoading = false;
+/** Shared in-flight promise for pending detections — avoids race conditions */
+let pendingDetection: Promise<Results> | null = null;
+let pendingResolve: ((results: Results) => void) | null = null;
+let pendingReject: ((error: Error) => void) | null = null;
+let pendingTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+/** Detection timeout in milliseconds */
+const DETECTION_TIMEOUT_MS = 5000;
+
+/** MediaPipe Face Mesh version — must match package.json dependency */
+const MEDIAPIPE_VERSION = "0.4.1657299874";
+
+/** Types that MediaPipe FaceMesh accepts */
+type MediaPipeImageSource =
+	| HTMLImageElement
+	| HTMLCanvasElement
+	| HTMLVideoElement;
+
+/** Clear the pending timeout if it exists */
+function clearPendingTimeout(): void {
+	if (pendingTimeoutId !== null) {
+		clearTimeout(pendingTimeoutId);
+		pendingTimeoutId = null;
+	}
+}
+
+/** Check if source is a valid MediaPipe image source */
+function isMediaPipeImageSource(
+	source: CanvasImageSource,
+): source is MediaPipeImageSource {
+	return (
+		source instanceof HTMLImageElement ||
+		source instanceof HTMLCanvasElement ||
+		source instanceof HTMLVideoElement
+	);
+}
+
+/** Convert OffscreenCanvas to HTMLCanvasElement for MediaPipe compatibility */
+function toHTMLCanvas(source: OffscreenCanvas): HTMLCanvasElement {
+	const canvas = document.createElement("canvas");
+	canvas.width = source.width;
+	canvas.height = source.height;
+	const ctx = canvas.getContext("2d");
+	if (ctx) {
+		ctx.drawImage(source, 0, 0);
+	}
+	return canvas;
+}
+
+/** Prepare source for MediaPipe — converts OffscreenCanvas if needed */
+function prepareSourceForMediaPipe(
+	source: CanvasImageSource,
+): MediaPipeImageSource | null {
+	if (isMediaPipeImageSource(source)) {
+		return source;
+	}
+	if (source instanceof OffscreenCanvas) {
+		return toHTMLCanvas(source);
+	}
+	// ImageBitmap, SVGImageElement, VideoFrame are not supported
+	return null;
+}
+
+/** Lazy-load MediaPipe Face Mesh WASM module */
+async function loadFaceMesh(): Promise<FaceMeshType | null> {
+	if (faceMeshInstance) return faceMeshInstance;
+	if (isLoading) return null;
+
+	isLoading = true;
+	try {
+		const { FaceMesh } = await import("@mediapipe/face_mesh");
+		const fm = new FaceMesh({
+			locateFile: (file: string) =>
+				`https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@${MEDIAPIPE_VERSION}/${file}`,
+		});
+		fm.setOptions({
+			maxNumFaces: 1,
+			refineLandmarks: true,
+			minDetectionConfidence: 0.5,
+			minTrackingConfidence: 0.5,
+		});
+		fm.onResults((results: Results) => {
+			if (pendingResolve) {
+				clearPendingTimeout();
+				pendingResolve(results);
+				pendingResolve = null;
+				pendingReject = null;
+			}
+		});
+		faceMeshInstance = fm;
+		return fm;
+	} catch {
+		return null;
+	} finally {
+		isLoading = false;
+	}
+}
+
+/** MediaPipe face landmark indices for key regions */
+const LANDMARK_INDICES = {
+	leftCheek: 234,
+	rightCheek: 454,
+	jawBottom: 152,
+	jawLeft: 132,
+	jawRight: 361,
+	leftEyeCenter: 159,
+	rightEyeCenter: 386,
+	mouthCenter: 13,
+};
+
+/** Convert MediaPipe face landmarks to EffectContext */
+function landmarksToContext(
+	landmarks: Array<{ x: number; y: number; z: number }>,
+): EffectContext {
+	const lc = landmarks[LANDMARK_INDICES.leftCheek];
+	const rc = landmarks[LANDMARK_INDICES.rightCheek];
+	const jaw = landmarks[LANDMARK_INDICES.jawBottom];
+	const jawL = landmarks[LANDMARK_INDICES.jawLeft];
+	const jawR = landmarks[LANDMARK_INDICES.jawRight];
+
+	// Estimate cheek radius from face width
+	const faceWidth = Math.abs(rc.x - lc.x);
+	const cheekRadius = faceWidth * 0.15;
+
+	return {
+		faceDetected: true,
+		cheekLeft: [lc.x, lc.y],
+		cheekRight: [rc.x, rc.y],
+		cheekRadius,
+		jawPoints: [jaw.x, jaw.y, jawL.x, jawL.y, jawR.x, jawR.y],
+	};
+}
+
+/** Detect face in the given image source and return EffectContext */
+export async function detectFace(
+	source: CanvasImageSource,
+): Promise<EffectContext> {
+	const fm = await loadFaceMesh();
+	if (!fm) {
+		return { faceDetected: false };
+	}
+
+	// Convert source to MediaPipe-compatible format
+	const mediaPipeSource = prepareSourceForMediaPipe(source);
+	if (!mediaPipeSource) {
+		// Source type not supported by MediaPipe
+		return { faceDetected: false };
+	}
+
+	// Reuse existing in-flight detection if one exists
+	if (pendingDetection) {
+		const results = await pendingDetection;
+		if (
+			!results?.multiFaceLandmarks ||
+			results.multiFaceLandmarks.length === 0
+		) {
+			return { faceDetected: false };
+		}
+		return landmarksToContext(results.multiFaceLandmarks[0]);
+	}
+
+	// Create new detection promise with timeout
+	pendingDetection = new Promise<Results>((resolve, reject) => {
+		pendingResolve = resolve;
+		pendingReject = reject;
+
+		// Set up timeout for detection
+		pendingTimeoutId = setTimeout(() => {
+			if (pendingReject) {
+				pendingReject(new Error("Face detection timeout"));
+				pendingResolve = null;
+				pendingReject = null;
+				pendingDetection = null;
+				pendingTimeoutId = null;
+			}
+		}, DETECTION_TIMEOUT_MS);
+
+		// Send image for detection, catching sync errors
+		try {
+			fm.send({ image: mediaPipeSource });
+		} catch (error) {
+			clearPendingTimeout();
+			reject(error instanceof Error ? error : new Error(String(error)));
+		}
+	});
+
+	let results: Results;
+	try {
+		results = await pendingDetection;
+	} catch {
+		// Detection failed (timeout or error) — return no face detected
+		pendingDetection = null;
+		pendingResolve = null;
+		pendingReject = null;
+		return { faceDetected: false };
+	}
+
+	clearPendingTimeout();
+	pendingDetection = null;
+	pendingResolve = null;
+	pendingReject = null;
+
+	if (!results?.multiFaceLandmarks || results.multiFaceLandmarks.length === 0) {
+		return { faceDetected: false };
+	}
+
+	return landmarksToContext(results.multiFaceLandmarks[0]);
+}
+
+/** Check if MediaPipe is loaded (for conditional rendering) */
+export function isFaceMeshReady(): boolean {
+	return faceMeshInstance !== null;
+}
+
+/** Clean up MediaPipe resources */
+export function disposeFaceMesh(): void {
+	// Clear timeout and settle any pending detection before disposing
+	clearPendingTimeout();
+	if (pendingReject) {
+		pendingReject(new Error("Face mesh disposed"));
+		pendingReject = null;
+		pendingResolve = null;
+		pendingDetection = null;
+	}
+	if (faceMeshInstance) {
+		faceMeshInstance.close();
+		faceMeshInstance = null;
+	}
+}

--- a/apps/web/src/services/face-mesh/index.ts
+++ b/apps/web/src/services/face-mesh/index.ts
@@ -1,0 +1,5 @@
+export {
+	detectFace,
+	isFaceMeshReady,
+	disposeFaceMesh,
+} from "./face-mesh-provider";

--- a/apps/web/src/services/renderer/apply-spatial-transforms.ts
+++ b/apps/web/src/services/renderer/apply-spatial-transforms.ts
@@ -1,0 +1,36 @@
+import { transformsRegistry } from "@/lib/transforms";
+import type {
+	ClipTransform,
+	SpatialTransformRenderer,
+} from "@/lib/transforms/types";
+
+/**
+ * Apply enabled spatial clip transforms to a Canvas2D context, in order.
+ * Caller is responsible for `ctx.save()`/`ctx.restore()` around this call
+ * so the matrix/clip state doesn't leak into subsequent draws.
+ */
+export function applySpatialTransforms({
+	ctx,
+	transforms,
+	width,
+	height,
+}: {
+	ctx: CanvasRenderingContext2D;
+	transforms: ClipTransform[];
+	width: number;
+	height: number;
+}): void {
+	for (const transform of transforms) {
+		if (!transform.enabled) continue;
+		const definition = transformsRegistry.get(transform.type);
+		if (definition.renderer.type !== "spatial") continue;
+
+		const renderer = definition.renderer as SpatialTransformRenderer;
+		renderer.apply({
+			ctx,
+			transformParams: transform.params,
+			width,
+			height,
+		});
+	}
+}

--- a/apps/web/src/services/renderer/nodes/effect-layer-node.ts
+++ b/apps/web/src/services/renderer/nodes/effect-layer-node.ts
@@ -56,6 +56,7 @@ export class EffectLayerNode extends BaseNode<EffectLayerNodeParams> {
 			effectParams: this.params.effectParams,
 			width: renderer.width,
 			height: renderer.height,
+			time,
 		});
 		if (passes.length === 0) {
 			return;

--- a/apps/web/src/services/renderer/nodes/graphic-node.ts
+++ b/apps/web/src/services/renderer/nodes/graphic-node.ts
@@ -81,7 +81,7 @@ export class GraphicNode extends VisualNode<GraphicNodeParams> {
 			return;
 		}
 
-		this.renderVisual({
+		await this.renderVisual({
 			renderer,
 			source,
 			sourceWidth: DEFAULT_GRAPHIC_SOURCE_SIZE,

--- a/apps/web/src/services/renderer/nodes/image-node.ts
+++ b/apps/web/src/services/renderer/nodes/image-node.ts
@@ -79,7 +79,7 @@ export class ImageNode extends VisualNode<ImageNodeParams> {
 
 		const { source, width, height } = await this.cachedSource;
 
-		this.renderVisual({
+		await this.renderVisual({
 			renderer,
 			source,
 			sourceWidth: width || renderer.width,

--- a/apps/web/src/services/renderer/nodes/sticker-node.ts
+++ b/apps/web/src/services/renderer/nodes/sticker-node.ts
@@ -65,7 +65,7 @@ export class StickerNode extends VisualNode<StickerNodeParams> {
 		const sourceWidth = this.params.intrinsicWidth ?? loadedWidth;
 		const sourceHeight = this.params.intrinsicHeight ?? loadedHeight;
 
-		this.renderVisual({
+		await this.renderVisual({
 			renderer,
 			source,
 			sourceWidth,

--- a/apps/web/src/services/renderer/nodes/video-node.ts
+++ b/apps/web/src/services/renderer/nodes/video-node.ts
@@ -25,7 +25,7 @@ export class VideoNode extends VisualNode<VideoNodeParams> {
 		});
 
 		if (frame) {
-			this.renderVisual({
+			await this.renderVisual({
 				renderer,
 				source: frame.canvas,
 				sourceWidth: frame.canvas.width,

--- a/apps/web/src/services/renderer/nodes/visual-node.ts
+++ b/apps/web/src/services/renderer/nodes/visual-node.ts
@@ -14,8 +14,11 @@ import {
 import { resolveEffectParamsAtTime } from "@/lib/animation/effect-param-channel";
 import { TIME_EPSILON_SECONDS } from "@/constants/animation-constants";
 import { effectsRegistry, resolveEffectPasses } from "@/lib/effects";
+import { EffectCategory } from "@/lib/effects/categories";
+import type { EffectContext } from "@/lib/effects/types";
 import { masksRegistry } from "@/lib/masks";
 import { getSourceTimeAtClipTime } from "@/lib/retime";
+import { detectFace } from "@/services/face-mesh";
 import { webglEffectRenderer } from "../webgl/webgl-effect-renderer";
 import { applyMaskFeather } from "../mask-feather";
 
@@ -63,7 +66,7 @@ export abstract class VisualNode<
 		);
 	}
 
-	protected renderVisual({
+	protected async renderVisual({
 		renderer,
 		source,
 		sourceWidth,
@@ -75,7 +78,7 @@ export abstract class VisualNode<
 		sourceWidth: number;
 		sourceHeight: number;
 		timelineTime: number;
-	}): void {
+	}): Promise<void> {
 		renderer.context.save();
 
 		const animationLocalTime = this.getAnimationLocalTime({
@@ -134,7 +137,7 @@ export abstract class VisualNode<
 
 		const currentResult =
 			enabledEffects.length > 0
-				? this.applyEffects({
+				? await this.applyEffects({
 						source,
 						effects: enabledEffects,
 						width: absWidth,
@@ -178,7 +181,7 @@ export abstract class VisualNode<
 		renderer.context.restore();
 	}
 
-	private applyEffects({
+	private async applyEffects({
 		source,
 		effects,
 		width,
@@ -190,7 +193,15 @@ export abstract class VisualNode<
 		width: number;
 		height: number;
 		animationLocalTime: number;
-	}): CanvasImageSource {
+	}): Promise<CanvasImageSource> {
+		const needsFaceContext = effects.some(
+			(effect) =>
+				effectsRegistry.get(effect.type).category === EffectCategory.BEAUTY,
+		);
+		const faceContext: EffectContext | undefined = needsFaceContext
+			? await detectFace(source)
+			: undefined;
+
 		let current: CanvasImageSource = source;
 		for (const effect of effects) {
 			const resolvedParams = resolveEffectParamsAtTime({
@@ -204,6 +215,8 @@ export abstract class VisualNode<
 				effectParams: resolvedParams,
 				width,
 				height,
+				time: animationLocalTime,
+				context: definition.category === EffectCategory.BEAUTY ? faceContext : undefined,
 			});
 			current = webglEffectRenderer.applyEffect({
 				source: current,

--- a/apps/web/src/services/renderer/nodes/visual-node.ts
+++ b/apps/web/src/services/renderer/nodes/visual-node.ts
@@ -3,6 +3,7 @@ import { createOffscreenCanvas } from "../canvas-utils";
 import { BaseNode } from "./base-node";
 import type { Effect } from "@/lib/effects/types";
 import type { Mask } from "@/lib/masks/types";
+import type { ClipTransform } from "@/lib/transforms/types";
 import type { BlendMode, Transform } from "@/lib/rendering";
 import type { ElementAnimations } from "@/lib/animation/types";
 import type { RetimeConfig } from "@/lib/timeline";
@@ -12,6 +13,7 @@ import {
 	resolveTransformAtTime,
 } from "@/lib/animation";
 import { resolveEffectParamsAtTime } from "@/lib/animation/effect-param-channel";
+import { resolveTransformParamsAtTime } from "@/lib/animation/transform-param-channel";
 import { TIME_EPSILON_SECONDS } from "@/constants/animation-constants";
 import { effectsRegistry, resolveEffectPasses } from "@/lib/effects";
 import { EffectCategory } from "@/lib/effects/categories";
@@ -20,6 +22,8 @@ import { masksRegistry } from "@/lib/masks";
 import { getSourceTimeAtClipTime } from "@/lib/retime";
 import { detectFace } from "@/services/face-mesh";
 import { webglEffectRenderer } from "../webgl/webgl-effect-renderer";
+import { webglTransformRenderer } from "../webgl/webgl-transform-renderer";
+import { applySpatialTransforms } from "../apply-spatial-transforms";
 import { applyMaskFeather } from "../mask-feather";
 
 export interface VisualNodeParams {
@@ -34,6 +38,7 @@ export interface VisualNodeParams {
 	blendMode?: BlendMode;
 	effects?: Effect[];
 	masks?: Mask[];
+	clipTransforms?: ClipTransform[];
 }
 
 export abstract class VisualNode<
@@ -61,8 +66,7 @@ export abstract class VisualNode<
 	protected isInRange({ time }: { time: number }): boolean {
 		const localTime = time - this.params.timeOffset;
 		return (
-			localTime >= -TIME_EPSILON_SECONDS &&
-			localTime < this.params.duration
+			localTime >= -TIME_EPSILON_SECONDS && localTime < this.params.duration
 		);
 	}
 
@@ -128,14 +132,22 @@ export abstract class VisualNode<
 		const enabledEffects =
 			this.params.effects?.filter((effect) => effect.enabled) ?? [];
 		const activeMasks = this.params.masks ?? [];
+		const enabledTransforms =
+			this.params.clipTransforms?.filter(
+				(clipTransform) => clipTransform.enabled,
+			) ?? [];
 
-		if (activeMasks.length === 0 && enabledEffects.length === 0) {
+		if (
+			activeMasks.length === 0 &&
+			enabledEffects.length === 0 &&
+			enabledTransforms.length === 0
+		) {
 			renderer.context.drawImage(source, x, y, absWidth, absHeight);
 			renderer.context.restore();
 			return;
 		}
 
-		const currentResult =
+		const afterEffects =
 			enabledEffects.length > 0
 				? await this.applyEffects({
 						source,
@@ -146,39 +158,139 @@ export abstract class VisualNode<
 					})
 				: source;
 
-		if (activeMasks.length === 0) {
-			renderer.context.drawImage(currentResult, x, y, absWidth, absHeight);
+		// Render pipeline order: effects -> masks -> transforms.
+		// Transforms reshape/reposition the final composited element, so they
+		// run last. This ordering is a provisional default pending maintainer
+		// confirmation — revisit if product requirements dictate otherwise.
+		const afterMasks =
+			activeMasks.length > 0
+				? this.applyMasks({
+						source: afterEffects,
+						masks: activeMasks,
+						scaledWidth: absWidth,
+						scaledHeight: absHeight,
+					})
+				: afterEffects;
+
+		if (enabledTransforms.length === 0) {
+			renderer.context.drawImage(afterMasks, x, y, absWidth, absHeight);
 			renderer.context.restore();
 			return;
 		}
 
+		const finalResult = this.applyClipTransforms({
+			source: afterMasks,
+			transforms: enabledTransforms,
+			width: absWidth,
+			height: absHeight,
+			animationLocalTime,
+		});
+
+		renderer.context.drawImage(finalResult, x, y, absWidth, absHeight);
+		renderer.context.restore();
+	}
+
+	private applyMasks({
+		source,
+		masks,
+		scaledWidth,
+		scaledHeight,
+	}: {
+		source: CanvasImageSource;
+		masks: Mask[];
+		scaledWidth: number;
+		scaledHeight: number;
+	}): CanvasImageSource {
 		const elementCanvas = createOffscreenCanvas({
-			width: Math.round(absWidth),
-			height: Math.round(absHeight),
+			width: Math.round(scaledWidth),
+			height: Math.round(scaledHeight),
 		});
 		const elementCtx = elementCanvas.getContext("2d") as
 			| CanvasRenderingContext2D
 			| OffscreenCanvasRenderingContext2D
 			| null;
 		if (!elementCtx) {
-			renderer.context.drawImage(currentResult, x, y, absWidth, absHeight);
-			renderer.context.restore();
-			return;
+			return source;
 		}
 
-		elementCtx.drawImage(currentResult, 0, 0, absWidth, absHeight);
+		elementCtx.drawImage(source, 0, 0, scaledWidth, scaledHeight);
 
-		for (const mask of activeMasks) {
+		for (const mask of masks) {
 			this.applyMask({
 				mask,
 				elementCtx,
-				scaledWidth: absWidth,
-				scaledHeight: absHeight,
+				scaledWidth,
+				scaledHeight,
 			});
 		}
 
-		renderer.context.drawImage(elementCanvas, x, y, absWidth, absHeight);
-		renderer.context.restore();
+		return elementCanvas;
+	}
+
+	private applyClipTransforms({
+		source,
+		transforms,
+		width,
+		height,
+		animationLocalTime,
+	}: {
+		source: CanvasImageSource;
+		transforms: ClipTransform[];
+		width: number;
+		height: number;
+		animationLocalTime: number;
+	}): CanvasImageSource {
+		let current: CanvasImageSource = source;
+
+		// Resolve each transform's params at the current animation time before
+		// handing off to the renderers, mirroring how applyEffects resolves
+		// effect params via resolveEffectParamsAtTime. Renderers only ever see
+		// the resolved (static-at-this-instant) param values, never raw
+		// keyframe arrays.
+		const resolvedTransforms: ClipTransform[] = transforms.map((transform) => ({
+			...transform,
+			params: resolveTransformParamsAtTime({
+				transform,
+				animations: this.params.animations,
+				localTime: animationLocalTime,
+			}),
+		}));
+
+		if (webglTransformRenderer.hasVisualTransforms(resolvedTransforms)) {
+			current = webglTransformRenderer.applyVisualTransforms({
+				source: current,
+				transforms: resolvedTransforms,
+				width: Math.round(width),
+				height: Math.round(height),
+				time: animationLocalTime,
+			});
+		}
+
+		if (webglTransformRenderer.hasSpatialTransforms(resolvedTransforms)) {
+			const spatialCanvas = createOffscreenCanvas({
+				width: Math.round(width),
+				height: Math.round(height),
+			});
+			const spatialCtx = spatialCanvas.getContext("2d") as
+				| CanvasRenderingContext2D
+				| OffscreenCanvasRenderingContext2D
+				| null;
+			if (spatialCtx) {
+				const ctx = spatialCtx as CanvasRenderingContext2D;
+				ctx.save();
+				applySpatialTransforms({
+					ctx,
+					transforms: resolvedTransforms,
+					width,
+					height,
+				});
+				ctx.drawImage(current, 0, 0, width, height);
+				ctx.restore();
+				current = spatialCanvas;
+			}
+		}
+
+		return current;
 	}
 
 	private async applyEffects({
@@ -216,7 +328,10 @@ export abstract class VisualNode<
 				width,
 				height,
 				time: animationLocalTime,
-				context: definition.category === EffectCategory.BEAUTY ? faceContext : undefined,
+				context:
+					definition.category === EffectCategory.BEAUTY
+						? faceContext
+						: undefined,
 			});
 			current = webglEffectRenderer.applyEffect({
 				source: current,

--- a/apps/web/src/services/renderer/scene-builder.ts
+++ b/apps/web/src/services/renderer/scene-builder.ts
@@ -78,6 +78,7 @@ function buildTrackNodes({
 							blendMode: element.blendMode,
 							effects: element.effects,
 							masks: element.masks,
+							clipTransforms: element.clipTransforms,
 						}),
 					);
 				}
@@ -95,6 +96,7 @@ function buildTrackNodes({
 							blendMode: element.blendMode,
 							effects: element.effects,
 							masks: element.masks,
+							clipTransforms: element.clipTransforms,
 							...(isPreview && {
 								maxSourceSize: PREVIEW_MAX_IMAGE_SIZE,
 							}),
@@ -130,6 +132,7 @@ function buildTrackNodes({
 						opacity: element.opacity,
 						blendMode: element.blendMode,
 						effects: element.effects,
+						clipTransforms: element.clipTransforms,
 					}),
 				);
 			}
@@ -149,6 +152,7 @@ function buildTrackNodes({
 						blendMode: element.blendMode,
 						effects: element.effects,
 						masks: element.masks,
+						clipTransforms: element.clipTransforms,
 					}),
 				);
 			}

--- a/apps/web/src/services/renderer/transform-preview.ts
+++ b/apps/web/src/services/renderer/transform-preview.ts
@@ -1,0 +1,270 @@
+import { createOffscreenCanvas } from "./canvas-utils";
+import { transformsRegistry } from "@/lib/transforms";
+import { buildDefaultParamValues } from "@/lib/registry";
+import type { ParamValues } from "@/lib/params";
+import { applyMultiPassEffect } from "./webgl/webgl-utils";
+import type { EffectPassData } from "./webgl/webgl-utils";
+
+const PREVIEW_SIZE = 160;
+const PREVIEW_IMAGE_PATH = "/effects/preview.jpg";
+
+/**
+ * Renders a small preview thumbnail for a transform definition, applying
+ * it to a static test image. Mirrors `EffectPreviewService`
+ * (`services/renderer/effect-preview.ts`) — spatial transforms render via
+ * Canvas2D, webgl (visual) transforms render via the shared multi-pass
+ * WebGL utilities. Transitions have no single-source preview and fall
+ * back to showing the unmodified source image.
+ */
+class TransformPreviewService {
+	private previewGl: WebGLRenderingContext | null = null;
+	private previewCanvas: OffscreenCanvas | HTMLCanvasElement | null = null;
+	private testSourceCanvas: OffscreenCanvas | HTMLCanvasElement | null = null;
+	private previewImageElement: HTMLImageElement | null = null;
+	private programCache = new Map<string, WebGLProgram>();
+	private onReadyCallbacks = new Set<() => void>();
+
+	readonly PREVIEW_SIZE = PREVIEW_SIZE;
+
+	constructor() {
+		this.loadPreviewImage();
+	}
+
+	onPreviewImageReady({ callback }: { callback: () => void }): () => void {
+		this.onReadyCallbacks.add(callback);
+		return () => this.onReadyCallbacks.delete(callback);
+	}
+
+	renderPreview({
+		transformType,
+		params,
+		targetCanvas,
+	}: {
+		transformType: string;
+		params: ParamValues;
+		targetCanvas: HTMLCanvasElement;
+	}): void {
+		const size = PREVIEW_SIZE;
+		const source = this.getTestSource({ width: size, height: size });
+		if (!source) return;
+
+		const definition = transformsRegistry.get(transformType);
+		const resolvedParams =
+			Object.keys(params).length > 0
+				? params
+				: buildDefaultParamValues(definition.params);
+
+		let result: OffscreenCanvas | HTMLCanvasElement;
+
+		if (definition.renderer.type === "spatial") {
+			result = this.applySpatialTransform({
+				source,
+				width: size,
+				height: size,
+				transformType,
+				params: resolvedParams,
+			});
+		} else if (definition.renderer.type === "webgl") {
+			result = this.applyWebglTransform({
+				source,
+				width: size,
+				height: size,
+				transformType,
+				params: resolvedParams,
+			});
+		} else {
+			// Transitions have no single-source preview; show source as-is.
+			result = source as OffscreenCanvas | HTMLCanvasElement;
+		}
+
+		const targetCtx = targetCanvas.getContext(
+			"2d",
+		) as CanvasRenderingContext2D | null;
+		if (targetCtx) {
+			targetCanvas.width = size;
+			targetCanvas.height = size;
+			targetCtx.drawImage(result, 0, 0, size, size);
+		}
+	}
+
+	private loadPreviewImage(): void {
+		if (typeof window === "undefined") return;
+		const image = new Image();
+		image.onload = () => {
+			this.testSourceCanvas = null;
+			for (const callback of this.onReadyCallbacks) {
+				callback();
+			}
+		};
+		image.src = PREVIEW_IMAGE_PATH;
+		this.previewImageElement = image;
+	}
+
+	private createTestSource({
+		width,
+		height,
+	}: {
+		width: number;
+		height: number;
+	}): OffscreenCanvas | HTMLCanvasElement | null {
+		const isImageReady =
+			this.previewImageElement?.complete &&
+			(this.previewImageElement.naturalWidth ?? 0) > 0;
+		if (!isImageReady || !this.previewImageElement) {
+			return null;
+		}
+
+		const canvas = createOffscreenCanvas({ width, height });
+		const ctx = canvas.getContext("2d") as
+			| CanvasRenderingContext2D
+			| OffscreenCanvasRenderingContext2D
+			| null;
+		if (!ctx) {
+			throw new Error("failed to get 2d context for test source");
+		}
+		ctx.drawImage(this.previewImageElement, 0, 0, width, height);
+		return canvas;
+	}
+
+	private getTestSource({
+		width,
+		height,
+	}: {
+		width: number;
+		height: number;
+	}): CanvasImageSource | null {
+		if (
+			!this.testSourceCanvas ||
+			this.testSourceCanvas.width !== width ||
+			this.testSourceCanvas.height !== height
+		) {
+			this.testSourceCanvas = this.createTestSource({ width, height });
+		}
+		return this.testSourceCanvas;
+	}
+
+	private applySpatialTransform({
+		source,
+		width,
+		height,
+		transformType,
+		params,
+	}: {
+		source: CanvasImageSource;
+		width: number;
+		height: number;
+		transformType: string;
+		params: ParamValues;
+	}): OffscreenCanvas | HTMLCanvasElement {
+		const definition = transformsRegistry.get(transformType);
+		if (definition.renderer.type !== "spatial") {
+			throw new Error(`Transform ${transformType} is not spatial`);
+		}
+
+		const outputCanvas = createOffscreenCanvas({ width, height });
+		const ctx = outputCanvas.getContext("2d") as
+			| CanvasRenderingContext2D
+			| OffscreenCanvasRenderingContext2D
+			| null;
+		if (!ctx) {
+			throw new Error("failed to get 2d context");
+		}
+
+		ctx.save();
+		definition.renderer.apply({
+			ctx: ctx as CanvasRenderingContext2D,
+			transformParams: params,
+			width,
+			height,
+		});
+		ctx.drawImage(source, 0, 0, width, height);
+		ctx.restore();
+
+		return outputCanvas;
+	}
+
+	private getOrCreatePreviewContext({
+		width,
+		height,
+	}: {
+		width: number;
+		height: number;
+	}): {
+		canvas: OffscreenCanvas | HTMLCanvasElement;
+		gl: WebGLRenderingContext;
+	} {
+		if (!this.previewCanvas || !this.previewGl) {
+			this.previewCanvas = createOffscreenCanvas({ width, height });
+			this.previewGl = this.previewCanvas.getContext("webgl", {
+				premultipliedAlpha: false,
+			}) as WebGLRenderingContext | null;
+			if (!this.previewGl) {
+				throw new Error("WebGL not supported");
+			}
+		}
+		if (
+			this.previewCanvas.width !== width ||
+			this.previewCanvas.height !== height
+		) {
+			this.previewCanvas.width = width;
+			this.previewCanvas.height = height;
+		}
+		return { canvas: this.previewCanvas, gl: this.previewGl };
+	}
+
+	private applyWebglTransform({
+		source,
+		width,
+		height,
+		transformType,
+		params,
+	}: {
+		source: CanvasImageSource;
+		width: number;
+		height: number;
+		transformType: string;
+		params: ParamValues;
+	}): OffscreenCanvas | HTMLCanvasElement {
+		const definition = transformsRegistry.get(transformType);
+		if (definition.renderer.type !== "webgl") {
+			throw new Error(`Transform ${transformType} is not a webgl transform`);
+		}
+
+		const { canvas: glCanvas, gl } = this.getOrCreatePreviewContext({
+			width,
+			height,
+		});
+
+		const passes: EffectPassData[] = [
+			{
+				fragmentShader: definition.renderer.fragmentShader,
+				uniforms: definition.renderer.uniforms({
+					transformParams: params,
+					width,
+					height,
+				}),
+			},
+		];
+
+		applyMultiPassEffect({
+			context: gl,
+			source,
+			width,
+			height,
+			passes,
+			programCache: this.programCache,
+		});
+
+		const outputCanvas = createOffscreenCanvas({ width, height });
+		const outputCtx = outputCanvas.getContext("2d") as
+			| CanvasRenderingContext2D
+			| OffscreenCanvasRenderingContext2D
+			| null;
+		if (outputCtx) {
+			outputCtx.drawImage(glCanvas, 0, 0, width, height);
+		}
+		return outputCanvas;
+	}
+}
+
+export const transformPreviewService = new TransformPreviewService();

--- a/apps/web/src/services/renderer/webgl/webgl-transform-renderer.ts
+++ b/apps/web/src/services/renderer/webgl/webgl-transform-renderer.ts
@@ -1,0 +1,83 @@
+import { getWebGLContext, readResult } from "./webgl-context";
+import { applyMultiPassEffect } from "./webgl-utils";
+import { transformsRegistry } from "@/lib/transforms";
+import type { ClipTransform } from "@/lib/transforms/types";
+import type { VisualTransformRenderer } from "@/lib/transforms/types";
+
+/**
+ * Apply enabled webgl (visual) clip transforms to a source image, in order.
+ * Spatial transforms are handled separately via Canvas2D matrix ops
+ * (see `applySpatialTransforms` in `visual-node.ts`).
+ */
+function applyVisualTransforms({
+	source,
+	transforms,
+	width,
+	height,
+	time,
+}: {
+	source: CanvasImageSource;
+	transforms: ClipTransform[];
+	width: number;
+	height: number;
+	time: number;
+}): CanvasImageSource {
+	const webglTransforms = transforms.filter((transform) => {
+		if (!transform.enabled) return false;
+		return transformsRegistry.get(transform.type).renderer.type === "webgl";
+	});
+
+	if (webglTransforms.length === 0) {
+		return source;
+	}
+
+	let current: CanvasImageSource = source;
+	for (const transform of webglTransforms) {
+		const definition = transformsRegistry.get(transform.type);
+		if (definition.renderer.type !== "webgl") continue;
+
+		const renderer = definition.renderer as VisualTransformRenderer;
+		const { context, programCache } = getWebGLContext({ width, height });
+		applyMultiPassEffect({
+			context,
+			source: current,
+			width,
+			height,
+			passes: [
+				{
+					fragmentShader: renderer.fragmentShader,
+					uniforms: renderer.uniforms({
+						transformParams: transform.params,
+						width,
+						height,
+						time,
+					}),
+				},
+			],
+			programCache,
+		});
+		current = readResult({ width, height });
+	}
+
+	return current;
+}
+
+function hasVisualTransforms(transforms: ClipTransform[]): boolean {
+	return transforms.some((transform) => {
+		if (!transform.enabled) return false;
+		return transformsRegistry.get(transform.type).renderer.type === "webgl";
+	});
+}
+
+function hasSpatialTransforms(transforms: ClipTransform[]): boolean {
+	return transforms.some((transform) => {
+		if (!transform.enabled) return false;
+		return transformsRegistry.get(transform.type).renderer.type === "spatial";
+	});
+}
+
+export const webglTransformRenderer = {
+	applyVisualTransforms,
+	hasVisualTransforms,
+	hasSpatialTransforms,
+};

--- a/apps/web/src/stores/assets-panel-store.tsx
+++ b/apps/web/src/stores/assets-panel-store.tsx
@@ -59,7 +59,7 @@ export const tabs = {
 	},
 	transitions: {
 		icon: createHugeiconsIcon({ icon: ArrowRightDoubleIcon }),
-		label: "Transitions",
+		label: "Transforms",
 	},
 	captions: {
 		icon: createHugeiconsIcon({ icon: ClosedCaptionIcon }),

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@hugeicons/core-free-icons": "^3.1.1",
         "@hugeicons/react": "^1.1.6",
         "@huggingface/transformers": "^3.8.1",
+        "@mediapipe/face_mesh": "0.4.1657299874",
         "@opencut/env": "workspace:*",
         "@opencut/ui": "workspace:*",
         "@opennextjs/cloudflare": "^1.18.0",
@@ -455,6 +456,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.29", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ=="],
 
+    "@mediapipe/face_mesh": ["@mediapipe/face_mesh@0.4.1657299874", "", {}, "sha512-Jdza+77HjDH4SQ6/DAYmnKUYdh2fU1GbhuGqXZbkK5rnJKpZLZe5KQeJmwUq9dmkYkCPSq4oe9vmcuveRPpwag=="],
+
     "@napi-rs/canvas": ["@napi-rs/canvas@0.1.92", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "0.1.92", "@napi-rs/canvas-darwin-arm64": "0.1.92", "@napi-rs/canvas-darwin-x64": "0.1.92", "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.92", "@napi-rs/canvas-linux-arm64-gnu": "0.1.92", "@napi-rs/canvas-linux-arm64-musl": "0.1.92", "@napi-rs/canvas-linux-riscv64-gnu": "0.1.92", "@napi-rs/canvas-linux-x64-gnu": "0.1.92", "@napi-rs/canvas-linux-x64-musl": "0.1.92", "@napi-rs/canvas-win32-arm64-msvc": "0.1.92", "@napi-rs/canvas-win32-x64-msvc": "0.1.92" } }, "sha512-q7ZaUCJkEU5BeOdE7fBx1XWRd2T5Ady65nxq4brMf5L4cE1VV/ACq5w9Z5b/IVJs8CwSSIwc30nlthH0gFo4Ig=="],
 
     "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@0.1.92", "", { "os": "android", "cpu": "arm64" }, "sha512-rDOtq53ujfOuevD5taxAuIFALuf1QsQWZe1yS/N4MtT+tNiDBEdjufvQRPWZ11FubL2uwgP8ApYU3YOaNu1ZsQ=="],
@@ -821,7 +824,7 @@
 
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.8.20", "", { "os": "win32", "cpu": "arm64" }, "sha512-voicVULvUV5yaGXo0Iue13BcHGYW3u0VgqSbfQwBaHbpj1zLjYV4KIe+7fYIo6DO8FVUJzxFps3ODCQG/Wy2Qw=="],
 
-    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/culori": ["@types/culori@4.0.1", "", {}, "sha512-43M51r/22CjhbOXyGT361GZ9vncSVQ39u62x5eJdBQFviI8zWp2X5jzqg7k4M6PVgDQAClpy2bUe2dtwEgEDVQ=="],
 
@@ -963,7 +966,7 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 


### PR DESCRIPTION
## Summary

Adds two effect/transform subsystems to the web editor, both conformed to the app's existing shared param/registry framework (`@/lib/params`, `@/lib/registry`) — no parallel type systems.

> **Base changed `main` → `dev`.** `main` was rewritten (TanStack/Rust) and no longer contains the web editor; this work targets `dev` where the editor lives. The branch was rebuilt on top of `dev`, so the previous approval was auto-dismissed — re-review appreciated.

### 1. Effects (`@/lib/effects`)
- **24 WebGL effects**: color/tone (brightness, contrast, saturation, exposure, gamma, color-balance, hue-shift, temperature), artistic (blur, sharpen, vignette, chromatic-aberration, pixelate, sketch, oil-paint, neon-glow, film-grain, glitch), and **face-aware beauty** (blush, eye-enhance, face-brighten, skin-smooth, slim-face, teeth-whiten).
- Preset system (beauty / cinematic / instagram).
- MediaPipe face-mesh service powers beauty effects; face detected once per chain only when a beauty effect is active.
- Framework additions (additive, backward-compatible): `EffectDefinition.category?`, `time?`/`context?` in `WebGLEffectPass.uniforms`, `resolveEffectPasses` forwards them.

### 2. Clip transforms (`@/lib/transforms`)
- **Spatial** (scale, rotate, translate, flip, crop) + **visual** (lens-distortion, perspective, wave) transforms applied per-clip.
- **Animated presets** (Ken Burns, cinematic zoom, rotate reveal) via a transform-param keyframe channel that mirrors the effect-param channel (`clipTransforms.<id>.params.<key>`); `resolveTransformParamsAtTime` resolves at render time.
- `clipTransforms` field on video/image/sticker/graphic elements (Text excluded — `TextNode` isn't a `VisualNode`).
- "Warp" property tab + Transforms assets view.

### Render pipeline
`effects → masks → transforms` (transforms reshape/reposition the final element). **Order is provisional** — flagged in a code comment; open to maintainer preference.

## Verification
- `tsc --noEmit`: clean (only 2 pre-existing `dev` test errors, untouched).
- `next build`: passes.
- `biome check`: clean.
- Effect tests + transform-preset animation test pass (`bun test`).

## Known limitations / follow-ups
- **Transitions** (fade/slide/wipe/zoom) are registered but **not yet wired** — needs dual-source clip-to-clip compositing at the scene-builder level (separate phase).
- **Preset easing falls back to `linear`** — the animation engine currently supports only linear/hold (no bezier/cubic).
- **Transforms are click-to-add** to the selected clip; no drag-onto-timeline yet (`TimelineDragData` has no "attach to element" case).
- The assets **"transitions" tab slot was repurposed** to host the Transforms view (was a placeholder); revisit if both tabs are wanted.
- `registerDefaultPresets()` (effects + transforms) is now called at startup (was previously unregistered).
