### PR TITLE
refactor(web): add runtime audio encoder capability negotiation for mp4 exports

### DIFF
--- a/apps/web/src/lib/export/audio-codec-support.ts
+++ b/apps/web/src/lib/export/audio-codec-support.ts
@@ -1,0 +1,45 @@
+const CANDIDATE_CONFIGS: AudioEncoderConfig[] = [
+	{
+		codec: "mp4a.40.2",
+		sampleRate: 44100,
+		numberOfChannels: 2,
+		bitrate: 192000,
+	},
+	{
+		codec: "mp4a.40.2",
+		sampleRate: 44100,
+		numberOfChannels: 2,
+		bitrate: 128000,
+	},
+	{
+		codec: "mp4a.40.2",
+		sampleRate: 44100,
+		numberOfChannels: 1,
+		bitrate: 128000,
+	},
+	{
+		codec: "mp4a.40.2",
+		sampleRate: 48000,
+		numberOfChannels: 2,
+		bitrate: 128000,
+	},
+];
+
+export async function resolveSupportedMp4AudioConfig(): Promise<AudioEncoderConfig | null> {
+	if (typeof AudioEncoder === "undefined") {
+		return null;
+	}
+
+	for (const config of CANDIDATE_CONFIGS) {
+		try {
+			const support = await AudioEncoder.isConfigSupported(config);
+			if (support.supported) {
+				return config;
+			}
+		} catch {
+			continue;
+		}
+	}
+
+	return null;
+}


### PR DESCRIPTION
## Code Quality

### Problem
Introduce a dedicated utility that probes browser support for AAC/WebCodecs audio settings instead of assuming a single hardcoded configuration (`mp4a.40.2`, 192 kbps, stereo, 44.1 kHz). This file should centralize support detection and fallback selection so ChromeOS/Chrome variants that reject the current config can still export with audio.

**Severity**: `high`
**File**: `apps/web/src/lib/export/audio-codec-support.ts`

### Solution
Implement a `resolveSupportedMp4AudioConfig()` function that:

### Changes
- `apps/web/src/lib/export/audio-codec-support.ts` (new)

⚠️ READ BEFORE SUBMITTING ⚠️

We are not currently accepting PRs except for critical bugs.

If this is a bug fix:
- [ ] I've opened an issue first
- [ ] This was approved by a maintainer

If this is a feature:

This PR will be closed. Please open an issue to discuss first.Contributed by Lê Thành Chỉnh
Code is a tool. Mindset is the real value.

Closes #718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio codec support detection has been implemented, enabling the application to automatically identify and select compatible audio encoding configurations for export operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->