### PR TITLE
feat: add JSON project export/import (closes #719)

### DIFF
--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import type { KeyboardEvent, MouseEvent } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import type { EditorCore } from "@/core";
 import { MigrationDialog } from "@/components/editor/dialogs/migration-dialog";
@@ -15,6 +15,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useEditor } from "@/hooks/use-editor";
+import { useFileUpload } from "@/hooks/use-file-upload";
 import { useProjectsStore } from "./store";
 import type {
 	TProjectMetadata,
@@ -532,45 +533,37 @@ function NewProjectButton() {
 function ImportProjectButton() {
 	const editor = useEditor();
 	const router = useRouter();
-	const fileInputRef = useRef<HTMLInputElement>(null);
 
-	const handleImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
-		const file = event.target.files?.[0];
-		if (!file) return;
+	const { openFilePicker, fileInputProps } = useFileUpload({
+		accept: ".json,.opencut.json",
+		multiple: false,
+		onFilesSelected: async (files) => {
+			const file = files[0];
+			if (!file) return;
 
-		try {
-			const json = await file.text();
-			const projectId = await editor.project.importProjectFromJSON({ json });
-			if (projectId) {
-				router.push(`/editor/${projectId}`);
+			try {
+				const json = await file.text();
+				const projectId = await editor.project.importProjectFromJSON({ json });
+				if (projectId) {
+					router.push(`/editor/${projectId}`);
+				}
+			} catch (error) {
+				toast.error("Failed to read file", {
+					description:
+						error instanceof Error ? error.message : "Please try again",
+				});
 			}
-		} catch (error) {
-			toast.error("Failed to read file", {
-				description:
-					error instanceof Error ? error.message : "Please try again",
-			});
-		}
-
-		// Reset the input so the same file can be re-selected
-		if (fileInputRef.current) {
-			fileInputRef.current.value = "";
-		}
-	};
+		},
+	});
 
 	return (
 		<>
-			<input
-				ref={fileInputRef}
-				type="file"
-				accept=".json,.opencut.json"
-				className="hidden"
-				onChange={handleImport}
-			/>
+			<input {...fileInputProps} />
 			<Button
 				size="lg"
 				variant="outline"
 				className="flex px-5 md:px-6"
-				onClick={() => fileInputRef.current?.click()}
+				onClick={openFilePicker}
 			>
 				<HugeiconsIcon icon={Upload01Icon} className="size-4" />
 				<span className="text-sm font-medium hidden md:block">Import</span>

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import type { KeyboardEvent, MouseEvent } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { EditorCore } from "@/core";
 import { MigrationDialog } from "@/components/editor/dialogs/migration-dialog";
@@ -45,6 +45,8 @@ import {
 	Edit03Icon,
 	ArrowDown02Icon,
 	InformationCircleIcon,
+	Download01Icon,
+	Upload01Icon,
 } from "@hugeicons/core-free-icons";
 import { OcVideoIcon } from "@/components/icons";
 import { Label } from "@/components/ui/label";
@@ -183,6 +185,7 @@ function ProjectsHeader() {
 
 				<div className="flex items-center gap-3 md:gap-4">
 					<SearchBar className="hidden md:block" />
+					<ImportProjectButton />
 					<NewProjectButton />
 				</div>
 			</div>
@@ -526,6 +529,56 @@ function NewProjectButton() {
 	);
 }
 
+function ImportProjectButton() {
+	const editor = useEditor();
+	const router = useRouter();
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const handleImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
+		const file = event.target.files?.[0];
+		if (!file) return;
+
+		try {
+			const json = await file.text();
+			const projectId = await editor.project.importProjectFromJSON({ json });
+			if (projectId) {
+				router.push(`/editor/${projectId}`);
+			}
+		} catch (error) {
+			toast.error("Failed to read file", {
+				description:
+					error instanceof Error ? error.message : "Please try again",
+			});
+		}
+
+		// Reset the input so the same file can be re-selected
+		if (fileInputRef.current) {
+			fileInputRef.current.value = "";
+		}
+	};
+
+	return (
+		<>
+			<input
+				ref={fileInputRef}
+				type="file"
+				accept=".json,.opencut.json"
+				className="hidden"
+				onChange={handleImport}
+			/>
+			<Button
+				size="lg"
+				variant="outline"
+				className="flex px-5 md:px-6"
+				onClick={() => fileInputRef.current?.click()}
+			>
+				<HugeiconsIcon icon={Upload01Icon} className="size-4" />
+				<span className="text-sm font-medium hidden md:block">Import</span>
+			</Button>
+		</>
+	);
+}
+
 function ProjectItem({
 	project,
 	allProjectIds,
@@ -557,6 +610,9 @@ function ProjectItem({
 	};
 	const handleDeleteClick = () => setIsDeleteDialogOpen(true);
 	const handleInfoClick = () => setIsInfoDialogOpen(true);
+	const handleExportJSON = async () => {
+		await editor.project.exportProjectByIdAsJSON({ id: project.id });
+	};
 	const handleDeleteConfirm = async () => {
 		await deleteProjects({ editor, ids: [project.id] });
 		setIsDeleteDialogOpen(false);
@@ -676,6 +732,7 @@ function ProjectItem({
 					onDuplicateClick={handleDuplicate}
 					onDeleteClick={handleDeleteClick}
 					onInfoClick={handleInfoClick}
+					onExportJSONClick={handleExportJSON}
 				/>
 			)}
 		</div>
@@ -717,6 +774,7 @@ function ProjectItem({
 										onDuplicateClick={handleDuplicate}
 										onDeleteClick={handleDeleteClick}
 										onInfoClick={handleInfoClick}
+										onExportJSONClick={handleExportJSON}
 									/>
 								)}
 							</>
@@ -730,6 +788,7 @@ function ProjectItem({
 					onDuplicateClick={handleDuplicate}
 					onDeleteClick={handleDeleteClick}
 					onInfoClick={handleInfoClick}
+					onExportJSONClick={handleExportJSON}
 				/>
 			</ContextMenu>
 
@@ -764,11 +823,13 @@ function ProjectContextMenuContent({
 	onDuplicateClick,
 	onDeleteClick,
 	onInfoClick,
+	onExportJSONClick,
 }: {
 	onRenameClick: () => void;
 	onDuplicateClick: () => void;
 	onDeleteClick: () => void;
 	onInfoClick: () => void;
+	onExportJSONClick: () => void;
 }) {
 	return (
 		<ContextMenuContent>
@@ -783,6 +844,12 @@ function ProjectContextMenuContent({
 				onClick={onDuplicateClick}
 			>
 				Duplicate
+			</ContextMenuItem>
+			<ContextMenuItem
+				icon={<HugeiconsIcon icon={Download01Icon} />}
+				onClick={onExportJSONClick}
+			>
+				Export as JSON
 			</ContextMenuItem>
 			<ContextMenuItem
 				icon={<HugeiconsIcon icon={InformationCircleIcon} />}
@@ -810,6 +877,7 @@ function ProjectMenu({
 	onDuplicateClick,
 	onDeleteClick,
 	onInfoClick,
+	onExportJSONClick,
 }: {
 	isOpen: boolean;
 	onOpenChange: (open: boolean) => void;
@@ -818,6 +886,7 @@ function ProjectMenu({
 	onDuplicateClick: () => void;
 	onDeleteClick: () => void;
 	onInfoClick: () => void;
+	onExportJSONClick: () => void;
 }) {
 	const handleMenuClick = ({
 		event,
@@ -857,6 +926,11 @@ function ProjectMenu({
 
 	const handleInfoClick = () => {
 		onInfoClick();
+		onOpenChange(false);
+	};
+
+	const handleExportJSON = () => {
+		onExportJSONClick();
 		onOpenChange(false);
 	};
 
@@ -901,6 +975,10 @@ function ProjectMenu({
 				<DropdownMenuItem onClick={handleDuplicate}>
 					<HugeiconsIcon icon={Copy01Icon} />
 					Duplicate
+				</DropdownMenuItem>
+				<DropdownMenuItem onClick={handleExportJSON}>
+					<HugeiconsIcon icon={Download01Icon} />
+					Export as JSON
 				</DropdownMenuItem>
 				<DropdownMenuItem onClick={handleInfoClick}>
 					<HugeiconsIcon icon={InformationCircleIcon} />

--- a/apps/web/src/components/editor/editor-header.tsx
+++ b/apps/web/src/components/editor/editor-header.tsx
@@ -19,7 +19,7 @@ import { ThemeToggle } from "../theme-toggle";
 import { DEFAULT_LOGO_URL, SOCIAL_LINKS } from "@/constants/site-constants";
 import { toast } from "sonner";
 import { useEditor } from "@/hooks/use-editor";
-import { CommandIcon, Logout05Icon } from "@hugeicons/core-free-icons";
+import { CommandIcon, Download01Icon, Logout05Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ShortcutsDialog } from "./dialogs/shortcuts-dialog";
 import Image from "next/image";
@@ -125,6 +125,13 @@ function ProjectDropdown() {
 						icon={<HugeiconsIcon icon={Logout05Icon} />}
 					>
 						Exit project
+					</DropdownMenuItem>
+
+					<DropdownMenuItem
+						onClick={() => editor.project.exportProjectAsJSON()}
+						icon={<HugeiconsIcon icon={Download01Icon} />}
+					>
+						Export as JSON
 					</DropdownMenuItem>
 
 					<DropdownMenuItem

--- a/apps/web/src/core/managers/project-manager.ts
+++ b/apps/web/src/core/managers/project-manager.ts
@@ -30,6 +30,7 @@ import { getElementFontFamilies } from "@/lib/timeline/element-utils";
 import { getRaisedProjectFpsForImportedMedia } from "@/lib/fps/utils";
 import type { MediaAsset } from "@/lib/media/types";
 import type { SerializedProject } from "@/services/storage/types";
+import { z } from "zod";
 
 /** Schema version for the JSON export format. Increment when the format changes. */
 const EXPORT_SCHEMA_VERSION = 1;
@@ -52,6 +53,74 @@ export interface ExportedProjectJSON {
 	project: SerializedProject;
 	media: ExportedMediaManifestEntry[];
 }
+
+/**
+ * Runtime validation for imported `.opencut.json` payloads.
+ *
+ * The importer persists the parsed structure directly to storage, so the whole
+ * timeline shape (scenes -> tracks -> elements), settings, and view state are
+ * validated here before {@link importProjectFromJSON} writes anything. Extra
+ * fields are tolerated for forward compatibility; missing or mistyped required
+ * fields are rejected so a malformed file cannot be saved and only fail later
+ * when the project is opened.
+ */
+const importedElementSchema = z.object({
+	id: z.string(),
+	type: z.string(),
+	name: z.string(),
+	duration: z.number(),
+	startTime: z.number(),
+	trimStart: z.number(),
+	trimEnd: z.number(),
+});
+
+const importedTrackSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	type: z.enum(["video", "text", "audio", "graphic", "effect"]),
+	elements: z.array(importedElementSchema),
+});
+
+const importedSceneTracksSchema = z.object({
+	overlay: z.array(importedTrackSchema),
+	main: importedTrackSchema,
+	audio: z.array(importedTrackSchema),
+});
+
+const importedSceneSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	isMain: z.boolean(),
+	tracks: importedSceneTracksSchema,
+	bookmarks: z.array(z.unknown()).optional(),
+});
+
+const importedSettingsSchema = z.object({
+	fps: z.number(),
+	canvasSize: z.object({ width: z.number(), height: z.number() }),
+	background: z.object({ type: z.string() }),
+});
+
+const importedTimelineViewStateSchema = z.object({
+	zoomLevel: z.number(),
+	scrollLeft: z.number(),
+	playheadTime: z.number(),
+});
+
+const importedProjectJsonSchema = z.object({
+	schema_version: z.number(),
+	project: z.object({
+		metadata: z.object({
+			name: z.string(),
+			duration: z.number().optional(),
+		}),
+		scenes: z.array(importedSceneSchema).min(1),
+		currentSceneId: z.string().optional(),
+		settings: importedSettingsSchema,
+		timelineViewState: importedTimelineViewStateSchema.optional(),
+	}),
+	media: z.array(z.unknown()).optional(),
+});
 
 export interface MigrationState {
 	isMigrating: boolean;
@@ -861,19 +930,20 @@ export class ProjectManager {
 		json: string;
 	}): Promise<string | null> {
 		try {
-			const parsed = JSON.parse(json) as ExportedProjectJSON;
+			const parsedJson: unknown = JSON.parse(json);
 
-			if (
-				!parsed.project ||
-				!parsed.project.metadata ||
-				!parsed.project.scenes ||
-				parsed.project.scenes.length === 0
-			) {
+			const validation = importedProjectJsonSchema.safeParse(parsedJson);
+			if (!validation.success) {
 				toast.error("Invalid project file", {
 					description: "The file does not contain a valid OpenCut project.",
 				});
 				return null;
 			}
+
+			// Structure validated above, so it is safe to treat the payload as an
+			// exported project. We keep the original parsed object (rather than the
+			// stripped `validation.data`) to preserve every element/track field.
+			const parsed = parsedJson as ExportedProjectJSON;
 
 			if (parsed.schema_version !== EXPORT_SCHEMA_VERSION) {
 				toast.error("Incompatible project file", {

--- a/apps/web/src/core/managers/project-manager.ts
+++ b/apps/web/src/core/managers/project-manager.ts
@@ -715,7 +715,9 @@ export class ProjectManager {
 				timelineViewState: project.timelineViewState,
 			};
 
-			const mediaAssets = this.editor.media.getAssets();
+			const mediaAssets = await storageService.loadAllMediaAssets({
+				projectId: project.metadata.id,
+			});
 			const mediaManifest: ExportedMediaManifestEntry[] = mediaAssets.map(
 				(asset) => ({
 					mediaId: asset.id,
@@ -864,10 +866,18 @@ export class ProjectManager {
 			if (
 				!parsed.project ||
 				!parsed.project.metadata ||
-				!parsed.project.scenes
+				!parsed.project.scenes ||
+				parsed.project.scenes.length === 0
 			) {
 				toast.error("Invalid project file", {
 					description: "The file does not contain a valid OpenCut project.",
+				});
+				return null;
+			}
+
+			if (parsed.schema_version !== EXPORT_SCHEMA_VERSION) {
+				toast.error("Incompatible project file", {
+					description: `Unsupported schema version ${parsed.schema_version}, expected ${EXPORT_SCHEMA_VERSION}.`,
 				});
 				return null;
 			}

--- a/apps/web/src/core/managers/project-manager.ts
+++ b/apps/web/src/core/managers/project-manager.ts
@@ -29,6 +29,29 @@ import { DEFAULTS } from "@/lib/timeline/defaults";
 import { getElementFontFamilies } from "@/lib/timeline/element-utils";
 import { getRaisedProjectFpsForImportedMedia } from "@/lib/fps/utils";
 import type { MediaAsset } from "@/lib/media/types";
+import type { SerializedProject } from "@/services/storage/types";
+
+/** Schema version for the JSON export format. Increment when the format changes. */
+const EXPORT_SCHEMA_VERSION = 1;
+
+/** Manifest entry describing a media asset referenced by the project. */
+export interface ExportedMediaManifestEntry {
+	mediaId: string;
+	filename: string;
+	type: string;
+	size: number;
+	width?: number;
+	height?: number;
+	duration?: number;
+}
+
+/** Top-level shape of an exported OpenCut project JSON file. */
+export interface ExportedProjectJSON {
+	schema_version: number;
+	exported_at: string;
+	project: SerializedProject;
+	media: ExportedMediaManifestEntry[];
+}
 
 export interface MigrationState {
 	isMigrating: boolean;
@@ -638,6 +661,270 @@ export class ProjectManager {
 	setActiveProject({ project }: { project: TProject }): void {
 		this.active = project;
 		this.notify();
+	}
+
+	/**
+	 * Exports the active project as a JSON file and triggers a browser download.
+	 *
+	 * The exported file includes the full serialized project data and a media
+	 * manifest listing every media asset referenced by the project (filename,
+	 * type, dimensions, duration). Media file blobs are **not** included -- the
+	 * manifest allows users to re-link media after import.
+	 */
+	async exportProjectAsJSON(): Promise<void> {
+		if (!this.active) {
+			toast.error("No active project to export");
+			return;
+		}
+
+		try {
+			const scenes = this.editor.scenes.getScenes();
+			const project = {
+				...this.active,
+				scenes,
+				metadata: {
+					...this.active.metadata,
+					duration: getProjectDurationFromScenes({ scenes }),
+					updatedAt: new Date(),
+				},
+			};
+
+			const serializedScenes = project.scenes.map((scene) => ({
+				id: scene.id,
+				name: scene.name,
+				isMain: scene.isMain,
+				tracks: scene.tracks,
+				bookmarks: scene.bookmarks,
+				createdAt: scene.createdAt.toISOString(),
+				updatedAt: scene.updatedAt.toISOString(),
+			}));
+
+			const serializedProject: SerializedProject = {
+				metadata: {
+					id: project.metadata.id,
+					name: project.metadata.name,
+					thumbnail: project.metadata.thumbnail,
+					duration: project.metadata.duration,
+					createdAt: project.metadata.createdAt.toISOString(),
+					updatedAt: project.metadata.updatedAt.toISOString(),
+				},
+				scenes: serializedScenes,
+				currentSceneId: project.currentSceneId,
+				settings: project.settings,
+				version: project.version,
+				timelineViewState: project.timelineViewState,
+			};
+
+			const mediaAssets = this.editor.media.getAssets();
+			const mediaManifest: ExportedMediaManifestEntry[] = mediaAssets.map(
+				(asset) => ({
+					mediaId: asset.id,
+					filename: asset.name,
+					type: asset.type,
+					size: asset.file.size,
+					width: asset.width,
+					height: asset.height,
+					duration: asset.duration,
+				}),
+			);
+
+			const exported: ExportedProjectJSON = {
+				schema_version: EXPORT_SCHEMA_VERSION,
+				exported_at: new Date().toISOString(),
+				project: serializedProject,
+				media: mediaManifest,
+			};
+
+			const json = JSON.stringify(exported, null, 2);
+			const blob = new Blob([json], { type: "application/json" });
+			const url = URL.createObjectURL(blob);
+
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = `${project.metadata.name.replace(/[^a-zA-Z0-9_-]/g, "_")}.opencut.json`;
+			document.body.appendChild(a);
+			a.click();
+			document.body.removeChild(a);
+			URL.revokeObjectURL(url);
+
+			toast.success("Project exported successfully");
+		} catch (error) {
+			console.error("Failed to export project:", error);
+			toast.error("Failed to export project", {
+				description:
+					error instanceof Error ? error.message : "Please try again",
+			});
+		}
+	}
+
+	/**
+	 * Exports any project (by ID) as a JSON file and triggers a browser download.
+	 *
+	 * Unlike {@link exportProjectAsJSON}, this does not require the project to be
+	 * active. It loads the project data directly from storage.
+	 */
+	async exportProjectByIdAsJSON({ id }: { id: string }): Promise<void> {
+		try {
+			const result = await storageService.loadProject({ id });
+			if (!result) {
+				toast.error("Project not found");
+				return;
+			}
+
+			const project = result.project;
+
+			const serializedScenes = project.scenes.map((scene) => ({
+				id: scene.id,
+				name: scene.name,
+				isMain: scene.isMain,
+				tracks: scene.tracks,
+				bookmarks: scene.bookmarks,
+				createdAt: scene.createdAt.toISOString(),
+				updatedAt: scene.updatedAt.toISOString(),
+			}));
+
+			const serializedProject: SerializedProject = {
+				metadata: {
+					id: project.metadata.id,
+					name: project.metadata.name,
+					thumbnail: project.metadata.thumbnail,
+					duration: project.metadata.duration,
+					createdAt: project.metadata.createdAt.toISOString(),
+					updatedAt: project.metadata.updatedAt.toISOString(),
+				},
+				scenes: serializedScenes,
+				currentSceneId: project.currentSceneId,
+				settings: project.settings,
+				version: project.version,
+				timelineViewState: project.timelineViewState,
+			};
+
+			const mediaAssets = await storageService.loadAllMediaAssets({
+				projectId: id,
+			});
+			const mediaManifest: ExportedMediaManifestEntry[] = mediaAssets.map(
+				(asset) => ({
+					mediaId: asset.id,
+					filename: asset.name,
+					type: asset.type,
+					size: asset.file.size,
+					width: asset.width,
+					height: asset.height,
+					duration: asset.duration,
+				}),
+			);
+
+			const exported: ExportedProjectJSON = {
+				schema_version: EXPORT_SCHEMA_VERSION,
+				exported_at: new Date().toISOString(),
+				project: serializedProject,
+				media: mediaManifest,
+			};
+
+			const json = JSON.stringify(exported, null, 2);
+			const blob = new Blob([json], { type: "application/json" });
+			const url = URL.createObjectURL(blob);
+
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = `${project.metadata.name.replace(/[^a-zA-Z0-9_-]/g, "_")}.opencut.json`;
+			document.body.appendChild(a);
+			a.click();
+			document.body.removeChild(a);
+			URL.revokeObjectURL(url);
+
+			toast.success("Project exported successfully");
+		} catch (error) {
+			console.error("Failed to export project:", error);
+			toast.error("Failed to export project", {
+				description:
+					error instanceof Error ? error.message : "Please try again",
+			});
+		}
+	}
+
+	/**
+	 * Imports a project from a JSON string previously created by {@link exportProjectAsJSON}.
+	 *
+	 * A new project is created with a fresh ID and timestamps. The timeline
+	 * structure (scenes, tracks, elements) is fully restored. Media files are
+	 * **not** included in the export, so elements that reference media assets
+	 * will need their media re-imported by the user.
+	 *
+	 * @returns The new project ID, or `null` if the import failed.
+	 */
+	async importProjectFromJSON({
+		json,
+	}: {
+		json: string;
+	}): Promise<string | null> {
+		try {
+			const parsed = JSON.parse(json) as ExportedProjectJSON;
+
+			if (
+				!parsed.project ||
+				!parsed.project.metadata ||
+				!parsed.project.scenes
+			) {
+				toast.error("Invalid project file", {
+					description: "The file does not contain a valid OpenCut project.",
+				});
+				return null;
+			}
+
+			const imported = parsed.project;
+
+			const newProjectId = generateUUID();
+			const now = new Date();
+
+			const scenes = imported.scenes.map((scene) => ({
+				id: scene.id,
+				name: scene.name,
+				isMain: scene.isMain,
+				tracks: scene.tracks,
+				bookmarks: scene.bookmarks ?? [],
+				createdAt: now,
+				updatedAt: now,
+			}));
+
+			const newProject: TProject = {
+				metadata: {
+					id: newProjectId,
+					name: imported.metadata.name,
+					duration:
+						imported.metadata.duration ??
+						getProjectDurationFromScenes({ scenes }),
+					createdAt: now,
+					updatedAt: now,
+				},
+				scenes,
+				currentSceneId: imported.currentSceneId || scenes[0]?.id || "",
+				settings: imported.settings,
+				version: CURRENT_PROJECT_VERSION,
+				timelineViewState: imported.timelineViewState,
+			};
+
+			await storageService.saveProject({ project: newProject });
+			this.updateMetadata(newProject);
+
+			const mediaCount = parsed.media?.length ?? 0;
+			if (mediaCount > 0) {
+				toast.success("Project imported", {
+					description: `${mediaCount} media file(s) need to be re-imported.`,
+				});
+			} else {
+				toast.success("Project imported successfully");
+			}
+
+			return newProjectId;
+		} catch (error) {
+			console.error("Failed to import project:", error);
+			toast.error("Failed to import project", {
+				description:
+					error instanceof Error ? error.message : "Please try again",
+			});
+			return null;
+		}
 	}
 
 	subscribe(listener: () => void): () => void {


### PR DESCRIPTION
## Summary

Adds JSON-based project export and import, as requested in #719.

**Export** serializes the active project (scenes, tracks, elements, settings) to a `.opencut.json` file and triggers a browser download. A media manifest is included listing every referenced media asset (mediaId, filename, type, dimensions, duration) so users know which files to re-import.

**Import** parses an `.opencut.json` file, validates the structure, creates a new project with a fresh ID, and opens it in the editor. Media files are not embedded in the export (keeping file sizes small) -- users re-import media after loading.

### Export format

```json
{
  "schema_version": 1,
  "exported_at": "2026-04-13T...",
  "project": { /* SerializedProject */ },
  "media": [
    {
      "mediaId": "abc-123",
      "filename": "intro.mp4",
      "type": "video",
      "size": 10485760,
      "width": 1920,
      "height": 1080,
      "duration": 5000
    }
  ]
}
```

### UI integration

- **Projects page**: "Import" button in the header (next to "New project"), "Export as JSON" in each project's context menu and dropdown menu
- **Editor**: "Export as JSON" in the project dropdown menu (logo menu, top-left)

### Design decisions

- No new dependencies
- `schema_version` field for forward compatibility
- Media blobs excluded to keep exports portable and small
- New project ID generated on import to avoid collisions
- Follows existing code patterns: same toast notifications, same error handling, same serialization logic as `StorageService`

Closes #719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Export as JSON** for individual projects across the editor and project menus/context menus, enabling one-click downloads.
  * Added **Import projects via JSON upload** from the projects page header, restoring project content and directing you to the newly created project in the editor.
  * Export/import operations include success and error notifications to confirm outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->