### PR TITLE
feat: add project export/import for cross-device transfers

### DIFF
--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -559,6 +559,7 @@ function ImportProjectButton() {
 				variant="outline"
 				className="flex px-5 md:px-6"
 				onClick={() => fileInputRef.current?.click()}
+				aria-label="Import project"
 			>
 				<HugeiconsIcon icon={Upload04Icon} className="size-4" />
 				<span className="text-sm font-medium hidden md:block">Import</span>

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -3,8 +3,8 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import type { KeyboardEvent, MouseEvent } from "react";
-import { useEffect, useState } from "react";
+import type { ChangeEvent, KeyboardEvent, MouseEvent } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { EditorCore } from "@/core";
 import { MigrationDialog } from "@/components/editor/dialogs/migration-dialog";
@@ -45,6 +45,8 @@ import {
 	Edit03Icon,
 	ArrowDown02Icon,
 	InformationCircleIcon,
+	Download04Icon,
+	Upload04Icon,
 } from "@hugeicons/core-free-icons";
 import { OcVideoIcon } from "@/components/icons";
 import { Label } from "@/components/ui/label";
@@ -183,6 +185,7 @@ function ProjectsHeader() {
 
 				<div className="flex items-center gap-3 md:gap-4">
 					<SearchBar className="hidden md:block" />
+					<ImportProjectButton />
 					<NewProjectButton />
 				</div>
 			</div>
@@ -526,6 +529,44 @@ function NewProjectButton() {
 	);
 }
 
+function ImportProjectButton() {
+	const editor = useEditor();
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const handleImport = async (event: ChangeEvent<HTMLInputElement>) => {
+		const file = event.target.files?.[0];
+		if (!file) return;
+
+		await editor.project.importProjectFromFile({ file });
+
+		// Reset the input so the same file can be imported again
+		if (fileInputRef.current) {
+			fileInputRef.current.value = "";
+		}
+	};
+
+	return (
+		<>
+			<input
+				ref={fileInputRef}
+				type="file"
+				accept=".opencut"
+				onChange={handleImport}
+				className="hidden"
+			/>
+			<Button
+				size="lg"
+				variant="outline"
+				className="flex px-5 md:px-6"
+				onClick={() => fileInputRef.current?.click()}
+			>
+				<HugeiconsIcon icon={Upload04Icon} className="size-4" />
+				<span className="text-sm font-medium hidden md:block">Import</span>
+			</Button>
+		</>
+	);
+}
+
 function ProjectItem({
 	project,
 	allProjectIds,
@@ -554,6 +595,9 @@ function ProjectItem({
 	const handleRename = () => setIsRenameDialogOpen(true);
 	const handleDuplicate = async () => {
 		await duplicateProjects({ editor, ids: [project.id] });
+	};
+	const handleExport = async () => {
+		await editor.project.exportProjectToFile({ id: project.id });
 	};
 	const handleDeleteClick = () => setIsDeleteDialogOpen(true);
 	const handleInfoClick = () => setIsInfoDialogOpen(true);
@@ -674,6 +718,7 @@ function ProjectItem({
 					variant="list"
 					onRenameClick={handleRename}
 					onDuplicateClick={handleDuplicate}
+					onExportClick={handleExport}
 					onDeleteClick={handleDeleteClick}
 					onInfoClick={handleInfoClick}
 				/>
@@ -715,6 +760,7 @@ function ProjectItem({
 										onOpenChange={setIsDropdownOpen}
 										onRenameClick={handleRename}
 										onDuplicateClick={handleDuplicate}
+										onExportClick={handleExport}
 										onDeleteClick={handleDeleteClick}
 										onInfoClick={handleInfoClick}
 									/>
@@ -728,6 +774,7 @@ function ProjectItem({
 				<ProjectContextMenuContent
 					onRenameClick={handleRename}
 					onDuplicateClick={handleDuplicate}
+					onExportClick={handleExport}
 					onDeleteClick={handleDeleteClick}
 					onInfoClick={handleInfoClick}
 				/>
@@ -762,11 +809,13 @@ function ProjectItem({
 function ProjectContextMenuContent({
 	onRenameClick,
 	onDuplicateClick,
+	onExportClick,
 	onDeleteClick,
 	onInfoClick,
 }: {
 	onRenameClick: () => void;
 	onDuplicateClick: () => void;
+	onExportClick: () => void;
 	onDeleteClick: () => void;
 	onInfoClick: () => void;
 }) {
@@ -783,6 +832,12 @@ function ProjectContextMenuContent({
 				onClick={onDuplicateClick}
 			>
 				Duplicate
+			</ContextMenuItem>
+			<ContextMenuItem
+				icon={<HugeiconsIcon icon={Download04Icon} />}
+				onClick={onExportClick}
+			>
+				Export
 			</ContextMenuItem>
 			<ContextMenuItem
 				icon={<HugeiconsIcon icon={InformationCircleIcon} />}
@@ -808,6 +863,7 @@ function ProjectMenu({
 	variant = "grid",
 	onRenameClick,
 	onDuplicateClick,
+	onExportClick,
 	onDeleteClick,
 	onInfoClick,
 }: {
@@ -816,6 +872,7 @@ function ProjectMenu({
 	variant?: "grid" | "list";
 	onRenameClick: () => void;
 	onDuplicateClick: () => void;
+	onExportClick: () => void;
 	onDeleteClick: () => void;
 	onInfoClick: () => void;
 }) {
@@ -847,6 +904,11 @@ function ProjectMenu({
 
 	const handleDuplicate = () => {
 		onDuplicateClick();
+		onOpenChange(false);
+	};
+
+	const handleExport = () => {
+		onExportClick();
 		onOpenChange(false);
 	};
 
@@ -901,6 +963,10 @@ function ProjectMenu({
 				<DropdownMenuItem onClick={handleDuplicate}>
 					<HugeiconsIcon icon={Copy01Icon} />
 					Duplicate
+				</DropdownMenuItem>
+				<DropdownMenuItem onClick={handleExport}>
+					<HugeiconsIcon icon={Download04Icon} />
+					Export
 				</DropdownMenuItem>
 				<DropdownMenuItem onClick={handleInfoClick}>
 					<HugeiconsIcon icon={InformationCircleIcon} />

--- a/apps/web/src/core/managers/project-manager.ts
+++ b/apps/web/src/core/managers/project-manager.ts
@@ -9,6 +9,7 @@ import type {
 } from "@/lib/project/types";
 import type { ExportOptions, ExportResult, ExportState } from "@/lib/export";
 import { storageService } from "@/services/storage/service";
+import type { SerializedProject } from "@/services/storage/types";
 import { toast } from "sonner";
 import { generateUUID } from "@/utils/id";
 import { UpdateProjectSettingsCommand } from "@/lib/commands/project";
@@ -638,6 +639,128 @@ export class ProjectManager {
 	setActiveProject({ project }: { project: TProject }): void {
 		this.active = project;
 		this.notify();
+	}
+
+	async exportProjectToFile({ id }: { id: string }): Promise<void> {
+		try {
+			const serializedProject =
+				await storageService.exportProjectToJSON({ id });
+			if (!serializedProject) {
+				toast.error("Project not found");
+				return;
+			}
+
+			const exportData = {
+				formatVersion: 1,
+				exportedAt: new Date().toISOString(),
+				project: serializedProject,
+			};
+
+			const json = JSON.stringify(exportData, null, 2);
+			const blob = new Blob([json], { type: "application/json" });
+			const url = URL.createObjectURL(blob);
+
+			const safeName = serializedProject.metadata.name
+				.replace(/[^a-zA-Z0-9_-]/g, "_")
+				.substring(0, 100);
+			const filename = `${safeName}.opencut`;
+
+			const link = document.createElement("a");
+			link.href = url;
+			link.download = filename;
+			document.body.appendChild(link);
+			link.click();
+			document.body.removeChild(link);
+			URL.revokeObjectURL(url);
+
+			toast.success("Project exported successfully");
+		} catch (error) {
+			console.error("Failed to export project:", error);
+			toast.error("Failed to export project", {
+				description:
+					error instanceof Error ? error.message : "Please try again",
+			});
+		}
+	}
+
+	async importProjectFromFile({
+		file,
+	}: {
+		file: File;
+	}): Promise<string | null> {
+		try {
+			const text = await file.text();
+			let parsed: unknown;
+
+			try {
+				parsed = JSON.parse(text);
+			} catch {
+				toast.error("Invalid file", {
+					description: "The file is not valid JSON",
+				});
+				return null;
+			}
+
+			const data = parsed as Record<string, unknown>;
+
+			if (
+				!data ||
+				typeof data !== "object" ||
+				!("formatVersion" in data) ||
+				!("project" in data)
+			) {
+				toast.error("Invalid file format", {
+					description: "This does not appear to be an OpenCut project file",
+				});
+				return null;
+			}
+
+			const serializedProject = data.project as SerializedProject;
+
+			if (
+				!serializedProject?.metadata?.id ||
+				!serializedProject?.metadata?.name ||
+				!Array.isArray(serializedProject?.scenes)
+			) {
+				toast.error("Invalid project data", {
+					description: "The project data is incomplete or corrupted",
+				});
+				return null;
+			}
+
+			// Assign a new ID to avoid collisions with existing projects
+			const newId = generateUUID();
+			serializedProject.metadata.id = newId;
+			serializedProject.metadata.updatedAt = new Date().toISOString();
+
+			await storageService.importProjectFromJSON({ serializedProject });
+
+			// Reload projects list
+			const metadata = {
+				id: serializedProject.metadata.id,
+				name: serializedProject.metadata.name,
+				thumbnail: serializedProject.metadata.thumbnail,
+				duration: serializedProject.metadata.duration ?? 0,
+				createdAt: new Date(serializedProject.metadata.createdAt),
+				updatedAt: new Date(serializedProject.metadata.updatedAt),
+			};
+
+			this.savedProjects = [metadata, ...this.savedProjects];
+			this.notify();
+
+			toast.success("Project imported successfully", {
+				description: serializedProject.metadata.name,
+			});
+
+			return newId;
+		} catch (error) {
+			console.error("Failed to import project:", error);
+			toast.error("Failed to import project", {
+				description:
+					error instanceof Error ? error.message : "Please try again",
+			});
+			return null;
+		}
 	}
 
 	subscribe(listener: () => void): () => void {

--- a/apps/web/src/core/managers/project-manager.ts
+++ b/apps/web/src/core/managers/project-manager.ts
@@ -31,6 +31,8 @@ import { getElementFontFamilies } from "@/lib/timeline/element-utils";
 import { getRaisedProjectFpsForImportedMedia } from "@/lib/fps/utils";
 import type { MediaAsset } from "@/lib/media/types";
 
+const SUPPORTED_FORMAT_VERSION = 1;
+
 export interface MigrationState {
 	isMigrating: boolean;
 	fromVersion: number | null;
@@ -651,7 +653,7 @@ export class ProjectManager {
 			}
 
 			const exportData = {
-				formatVersion: 1,
+				formatVersion: SUPPORTED_FORMAT_VERSION,
 				exportedAt: new Date().toISOString(),
 				project: serializedProject,
 			};
@@ -701,13 +703,10 @@ export class ProjectManager {
 				return null;
 			}
 
-			const data = parsed as Record<string, unknown>;
-
 			if (
-				!data ||
-				typeof data !== "object" ||
-				!("formatVersion" in data) ||
-				!("project" in data)
+				!parsed ||
+				typeof parsed !== "object" ||
+				Array.isArray(parsed)
 			) {
 				toast.error("Invalid file format", {
 					description: "This does not appear to be an OpenCut project file",
@@ -715,12 +714,38 @@ export class ProjectManager {
 				return null;
 			}
 
-			const serializedProject = data.project as SerializedProject;
+			const data = parsed as Record<string, unknown>;
+
+			if (data.formatVersion !== SUPPORTED_FORMAT_VERSION) {
+				toast.error("Unsupported file version", {
+					description: `Expected formatVersion ${SUPPORTED_FORMAT_VERSION}, got ${JSON.stringify(data.formatVersion)}`,
+				});
+				return null;
+			}
 
 			if (
-				!serializedProject?.metadata?.id ||
-				!serializedProject?.metadata?.name ||
-				!Array.isArray(serializedProject?.scenes)
+				!data.project ||
+				typeof data.project !== "object" ||
+				Array.isArray(data.project)
+			) {
+				toast.error("Invalid project data", {
+					description: "The project data is incomplete or corrupted",
+				});
+				return null;
+			}
+
+			const serializedProject = data.project as SerializedProject;
+			const meta = serializedProject.metadata as unknown as
+				| Record<string, unknown>
+				| undefined;
+
+			if (
+				!meta ||
+				typeof meta.id !== "string" ||
+				meta.id.trim() === "" ||
+				typeof meta.name !== "string" ||
+				meta.name.trim() === "" ||
+				!Array.isArray(serializedProject.scenes)
 			) {
 				toast.error("Invalid project data", {
 					description: "The project data is incomplete or corrupted",

--- a/apps/web/src/services/storage/service.ts
+++ b/apps/web/src/services/storage/service.ts
@@ -532,6 +532,9 @@ class StorageService {
 	}: {
 		serializedProject: SerializedProject;
 	}): Promise<void> {
+		// Migrations must complete before any write — otherwise the import races
+		// with the memoized ensureMigrations() and may end up in a half-migrated store.
+		await this.ensureMigrations();
 		await this.projectsAdapter.set(
 			serializedProject.metadata.id,
 			serializedProject,

--- a/apps/web/src/services/storage/service.ts
+++ b/apps/web/src/services/storage/service.ts
@@ -517,6 +517,27 @@ class StorageService {
 		return "indexedDB" in window;
 	}
 
+	async exportProjectToJSON({
+		id,
+	}: {
+		id: string;
+	}): Promise<SerializedProject | null> {
+		await this.ensureMigrations();
+		const serializedProject = await this.projectsAdapter.get(id);
+		return serializedProject ?? null;
+	}
+
+	async importProjectFromJSON({
+		serializedProject,
+	}: {
+		serializedProject: SerializedProject;
+	}): Promise<void> {
+		await this.projectsAdapter.set(
+			serializedProject.metadata.id,
+			serializedProject,
+		);
+	}
+
 	isFullySupported(): boolean {
 		return this.isIndexedDBSupported() && this.isOPFSSupported();
 	}


### PR DESCRIPTION
## Summary
- Add **Export Project**: downloads project as `.opencut` JSON file from project context menu or dropdown menu
- Add **Import Project**: loads `.opencut` file via Import button in the projects header toolbar
- Includes `formatVersion` field in export format for future compatibility
- Imported projects receive a new UUID to avoid collisions with existing projects

## Test plan
- [ ] Export a project with multiple tracks and effects
- [ ] Import the exported file on a fresh instance
- [ ] Verify all timeline data, tracks, and settings are preserved
- [ ] Verify invalid files show a clear error message
- [ ] Verify the same file can be imported multiple times (each gets a unique ID)

Fixes #751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import projects: Add projects by selecting .opencut files; imported projects are validated, added to the top of the project list, and surface success/failure notifications.
  * Export projects: Export any project as a .opencut file via project actions or context menu; downloads are triggered with success/failure notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenCut-app/OpenCut/pull/766?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->