### PR TITLE
fix(SaveManager): use getActiveOrNull to avoid race when leaving editor

### DIFF
--- a/apps/web/src/core/managers/save-manager.ts
+++ b/apps/web/src/core/managers/save-manager.ts
@@ -80,7 +80,7 @@ export class SaveManager {
 		if (this.isSaving) return;
 		if (!this.hasPendingSave) return;
 
-		const activeProject = this.editor.project.getActive();
+		const activeProject = this.editor.project.getActiveOrNull();
 		if (!activeProject) return;
 		if (this.editor.project.getIsLoading()) return;
 		if (this.editor.project.getMigrationState().isMigrating) return;


### PR DESCRIPTION
When closeProject() sets this.active = null, a debounced save scheduled before
  may still fire, causing getActive() to throw "No active project". The existing
  `if (!activeProject) return;` guard was dead code. Switching to getActiveOrNull
  makes the guard actually work.
    - 选 ⊙ Create a new branch for

⚠️ READ BEFORE SUBMITTING ⚠️

We are not currently accepting PRs except for critical bugs.

If this is a bug fix:
- [ ] I've opened an issue first
- [ ] This was approved by a maintainer

If this is a feature:

This PR will be closed. Please open an issue to discuss first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null-safety handling in the save functionality to ensure more robust operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->