### PR TITLE
fix the text being transparent when you click on it (ChromeOS)

### DIFF
--- a/apps/web/src/preview/components/text-edit-overlay.tsx
+++ b/apps/web/src/preview/components/text-edit-overlay.tsx
@@ -137,7 +137,7 @@ export function TextEditOverlay({
 					textAlign: element.textAlign,
 					letterSpacing: `${canvasLetterSpacing}px`,
 					lineHeight,
-					color: "transparent",
+					color: element.color,
 					caretColor: element.color,
 					backgroundColor: shouldShowBackground ? bg.color : "transparent",
 					minHeight: lineHeightPx,


### PR DESCRIPTION
⚠️ READ BEFORE SUBMITTING ⚠️

We are not currently accepting PRs except for critical bugs.

If this is a bug fix:
- [x] I've opened an issue first
- [ ] This was approved by a maintainer

If this is a feature:

This PR will be closed. Please open an issue to discuss first.

This PR changes the color from "transparent" to element.color in the TextEditOverlay() function.

Will close #770 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed text color visibility in the text editing interface—editable text now displays with the correct element color instead of appearing hidden, improving readability while editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->