### PR TITLE
Fix broken validation in delete-project-dialog

### DIFF
--- a/apps/web/src/project/components/delete-project-dialog.tsx
+++ b/apps/web/src/project/components/delete-project-dialog.tsx
@@ -81,7 +81,7 @@ export function DeleteProjectDialog({
 					<Button variant="outline" onClick={() => onOpenChange(false)}>
 						Cancel
 					</Button>
-					<Button variant="destructive" onClick={onConfirm} disabled={confirmationInput != REQUIRED_CONFIRMATION_TEXT}>
+					<Button variant="destructive" onClick={onConfirm} disabled={confirmationInput !== REQUIRED_CONFIRMATION_TEXT}>
 						Delete project
 					</Button>
 				</DialogFooter>

--- a/apps/web/src/project/components/delete-project-dialog.tsx
+++ b/apps/web/src/project/components/delete-project-dialog.tsx
@@ -64,10 +64,11 @@ export function DeleteProjectDialog({
 						</AlertDescription>
 					</Alert>
 					<div className="flex flex-col gap-3">
-						<Label className="text-xs font-semibold text-slate-500">
+						<Label htmlFor="confirmation-input" className="text-xs font-semibold text-slate-500">
 							{`Type "${REQUIRED_CONFIRMATION_TEXT}" to confirm`}
 						</Label>
 						<Input
+							id={"confirmation-input"}
 							onChange={(e) => {setConfirmationInput(e.target.value)}}
 							value={confirmationInput}
 							type="text"

--- a/apps/web/src/project/components/delete-project-dialog.tsx
+++ b/apps/web/src/project/components/delete-project-dialog.tsx
@@ -10,6 +10,9 @@ import {
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { useState } from "react";
+
+const REQUIRED_CONFIRMATION_TEXT = "DELETE";
 
 export function DeleteProjectDialog({
 	isOpen,
@@ -25,6 +28,8 @@ export function DeleteProjectDialog({
 	const count = projectNames.length;
 	const isSingle = count === 1;
 	const singleName = isSingle ? projectNames[0] : null;
+	
+	const [confirmationInput, setConfirmationInput] = useState<string>("");
 
 	return (
 		<Dialog open={isOpen} onOpenChange={onOpenChange}>
@@ -60,11 +65,13 @@ export function DeleteProjectDialog({
 					</Alert>
 					<div className="flex flex-col gap-3">
 						<Label className="text-xs font-semibold text-slate-500">
-							Type "DELETE" to confirm
+							{`Type "${REQUIRED_CONFIRMATION_TEXT}" to confirm`}
 						</Label>
 						<Input
+							onChange={(e) => {setConfirmationInput(e.target.value)}}
+							value={confirmationInput}
 							type="text"
-							placeholder="DELETE"
+							placeholder={REQUIRED_CONFIRMATION_TEXT}
 							size="lg"
 							variant="destructive"
 						/>
@@ -74,7 +81,7 @@ export function DeleteProjectDialog({
 					<Button variant="outline" onClick={() => onOpenChange(false)}>
 						Cancel
 					</Button>
-					<Button variant="destructive" onClick={onConfirm}>
+					<Button variant="destructive" onClick={onConfirm} disabled={confirmationInput != REQUIRED_CONFIRMATION_TEXT}>
 						Delete project
 					</Button>
 				</DialogFooter>


### PR DESCRIPTION
Fixes #724

### Changes made
1. Added a new state variable to track the value of the confirmation input
2. Introduced a constant for the required confirmation text
3. Disabled the delete button until the input matches that constant
4. Updated the input placeholder and label to use the required text instead of hardcoded strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project deletion now requires users to type a confirmation phrase before proceeding.
  * The delete button remains disabled until the entered text exactly matches the required confirmation, reducing accidental deletions.
  * Confirmation prompt and input placeholder were clarified to guide users on the exact text to enter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->