### PR TITLE
fix: resolve TypeScript build errors

### DIFF
--- a/apps/web/src/actions/keybinding.ts
+++ b/apps/web/src/actions/keybinding.ts
@@ -38,6 +38,22 @@ export type SingleCharacterShortcutKey = `${Key}`;
 
 export type ShortcutKey = ModifierBasedShortcutKey | SingleCharacterShortcutKey;
 
+const MODIFIER_KEYS_SET: ReadonlySet<string> = new Set([
+	"ctrl", "alt", "shift",
+	"ctrl+shift", "alt+shift", "ctrl+alt", "ctrl+alt+shift",
+]);
+
+export function isShortcutKey(value: string): value is ShortcutKey {
+	// Single key (e.g. "a", "enter")
+	if (isKey(value)) return true;
+	// Modifier+key (e.g. "ctrl+s", "ctrl+shift+z")
+	const lastPlus = value.lastIndexOf("+");
+	if (lastPlus === -1) return false;
+	const modifier = value.slice(0, lastPlus);
+	const key = value.slice(lastPlus + 1);
+	return MODIFIER_KEYS_SET.has(modifier) && isKey(key);
+}
+
 export type KeybindingConfig = {
 	[key in ShortcutKey]?: TActionWithOptionalArgs;
 };

--- a/apps/web/src/actions/types.ts
+++ b/apps/web/src/actions/types.ts
@@ -27,6 +27,11 @@ export type TActionWithNoArgs = Exclude<TAction, TActionWithArgs>;
 
 const ACTION_KEYS_SET: ReadonlySet<string> = new Set(Object.keys(ACTIONS));
 
+const ACTIONS_WITH_REQUIRED_ARGS: ReadonlySet<string> = new Set([
+	"remove-media-asset",
+	"remove-media-assets",
+]);
+
 export function isAction(value: string): value is TAction {
 	return ACTION_KEYS_SET.has(value);
 }
@@ -34,10 +39,6 @@ export function isAction(value: string): value is TAction {
 export function isActionWithOptionalArgs(value: string): value is TActionWithOptionalArgs {
 	if (!isAction(value)) return false;
 	// Actions that require mandatory (non-undefined) args cannot be used as keybindings
-	const ACTIONS_WITH_REQUIRED_ARGS: ReadonlySet<string> = new Set([
-		"remove-media-asset",
-		"remove-media-assets",
-	]);
 	return !ACTIONS_WITH_REQUIRED_ARGS.has(value);
 }
 

--- a/apps/web/src/actions/types.ts
+++ b/apps/web/src/actions/types.ts
@@ -1,5 +1,6 @@
 import type { MutableRefObject } from "react";
 import type { TAction } from "./definitions";
+import { ACTIONS } from "./definitions";
 
 export type { TAction };
 
@@ -23,6 +24,22 @@ export type TActionWithOptionalArgs =
 	| TKeysWithValueUndefined<TActionArgsMap>;
 
 export type TActionWithNoArgs = Exclude<TAction, TActionWithArgs>;
+
+const ACTION_KEYS_SET: ReadonlySet<string> = new Set(Object.keys(ACTIONS));
+
+export function isAction(value: string): value is TAction {
+	return ACTION_KEYS_SET.has(value);
+}
+
+export function isActionWithOptionalArgs(value: string): value is TActionWithOptionalArgs {
+	if (!isAction(value)) return false;
+	// Actions that require mandatory (non-undefined) args cannot be used as keybindings
+	const ACTIONS_WITH_REQUIRED_ARGS: ReadonlySet<string> = new Set([
+		"remove-media-asset",
+		"remove-media-assets",
+	]);
+	return !ACTIONS_WITH_REQUIRED_ARGS.has(value);
+}
 
 export type TArgOfAction<A extends TAction> = A extends TActionWithArgs
 	? TActionArgsMap[A]

--- a/apps/web/src/services/storage/migrations/runner.ts
+++ b/apps/web/src/services/storage/migrations/runner.ts
@@ -38,11 +38,11 @@ export async function runStorageMigrations({
 		hasCleanedUpMetaDb = true;
 	}
 
-	const projectsAdapter = new IndexedDBAdapter<ProjectRecord>(
-		"video-editor-projects",
-		"projects",
-		1,
-	);
+	const projectsAdapter = new IndexedDBAdapter<ProjectRecord>({
+		dbName: "video-editor-projects",
+		storeName: "projects",
+		version: 1,
+	});
 
 	const projects = await projectsAdapter.getAll();
 
@@ -95,7 +95,7 @@ export async function runStorageMigrations({
 				break;
 			}
 
-			await projectsAdapter.set(projectId, result.project);
+			await projectsAdapter.set({ key: projectId, value: result.project });
 			migratedCount++;
 			currentVersion = migration.to;
 			projectRecord = result.project;

--- a/apps/web/src/services/storage/migrations/v1-to-v2.ts
+++ b/apps/web/src/services/storage/migrations/v1-to-v2.ts
@@ -121,20 +121,20 @@ async function loadLegacyTracksForScene({
 	const sceneDbName = `video-editor-timelines-${projectId}-${sceneId}`;
 	const projectDbName = `video-editor-timelines-${projectId}`;
 
-	const adapter = new IndexedDBAdapter<LegacyTimelineData>(
-		sceneDbName,
-		"timeline",
-		1,
-	);
+	const adapter = new IndexedDBAdapter<LegacyTimelineData>({
+		dbName: sceneDbName,
+		storeName: "timeline",
+		version: 1,
+	});
 
 	let data = await adapter.get("timeline");
 
 	if (!data && isMain) {
-		const projectAdapter = new IndexedDBAdapter<LegacyTimelineData>(
-			projectDbName,
-			"timeline",
-			1,
-		);
+		const projectAdapter = new IndexedDBAdapter<LegacyTimelineData>({
+			dbName: projectDbName,
+			storeName: "timeline",
+			version: 1,
+		});
 		data = await projectAdapter.get("timeline");
 	}
 
@@ -157,11 +157,11 @@ async function loadMediaTypesById({
 		return {};
 	}
 
-	const mediaMetadataAdapter = new IndexedDBAdapter<MediaAssetData>(
-		`video-editor-media-${projectId}`,
-		"media-metadata",
-		1,
-	);
+	const mediaMetadataAdapter = new IndexedDBAdapter<MediaAssetData>({
+		dbName: `video-editor-media-${projectId}`,
+		storeName: "media-metadata",
+		version: 1,
+	});
 
 	const mediaEntries = await Promise.all(
 		mediaIds.map(async (mediaId) => {

--- a/apps/web/src/stickers/providers/index.ts
+++ b/apps/web/src/stickers/providers/index.ts
@@ -19,6 +19,6 @@ export function registerDefaultStickerProviders({
 		if (stickersRegistry.has(provider.id)) {
 			continue;
 		}
-		stickersRegistry.register(provider.id, provider);
+		stickersRegistry.register({ key: provider.id, definition: provider });
 	}
 }


### PR DESCRIPTION
## Summary

Fixes all 5 TypeScript errors reported in #782 that cause `bun run build` and Docker builds to fail on `main`.

Closes #782

## Changes

### 1. `src/actions/keybinding.ts`
Added missing `isShortcutKey` type guard function that `persistence.ts` imports but didn't exist.

### 2. `src/actions/types.ts`
Added missing `isAction` and `isActionWithOptionalArgs` type guard functions that `persistence.ts` imports but didn't exist. `ACTIONS_WITH_REQUIRED_ARGS` is declared at module scope to avoid recreating the Set on every call.

### 3. `src/services/storage/migrations/runner.ts` & `v1-to-v2.ts`
Fixed `IndexedDBAdapter` constructor calls — the constructor takes a single object `{ dbName, storeName, version }` but was being called with 3 positional arguments (3 occurrences).

Also fixed `projectsAdapter.set(projectId, result.project)` → `projectsAdapter.set({ key: projectId, value: result.project })` to match the adapter's actual API.

### 4. `src/stickers/providers/index.ts`
Fixed `stickersRegistry.register(id, provider)` → `stickersRegistry.register({ key: id, definition: provider })` to match `DefinitionRegistry.register`'s object param signature.

## Testing
- `bun run build` now completes successfully ✅
- TypeScript check passes ✅
- Docker build should now succeed ✅