### PR TITLE
feat(preview): add loop toggle for timeline playback

### DIFF
--- a/apps/web/src/core/managers/playback-manager.ts
+++ b/apps/web/src/core/managers/playback-manager.ts
@@ -224,12 +224,26 @@ export class PlaybackManager {
 		const maxTime = this.editor.timeline.getTotalDuration();
 
 		if (newTime >= maxTime) {
+			const shouldLoop =
+				this.editor.project.getActive()?.settings.loop === true &&
+				maxTime > ZERO_MEDIA_TIME;
+
+			if (shouldLoop) {
+				this.playbackStartWallTime = performance.now();
+				this.playbackStartTime = ZERO_MEDIA_TIME;
+				this.currentTime = ZERO_MEDIA_TIME;
+				this.notifySeek(ZERO_MEDIA_TIME);
+				this.dispatchSeekEvent(ZERO_MEDIA_TIME);
+				this.playbackTimer = requestAnimationFrame(this.updateTime);
+				return;
+			}
+
 			this.pause();
 			this.currentTime = maxTime;
 			this.notify();
-		this.notifySeek(maxTime);
-		this.dispatchSeekEvent(maxTime);
-		return;
+			this.notifySeek(maxTime);
+			this.dispatchSeekEvent(maxTime);
+			return;
 		}
 
 		this.currentTime = newTime;

--- a/apps/web/src/preview/components/toolbar.tsx
+++ b/apps/web/src/preview/components/toolbar.tsx
@@ -10,7 +10,10 @@ import {
 	FullScreenIcon,
 	PauseIcon,
 	PlayIcon,
+	RepeatIcon,
+	RepeatOffIcon,
 } from "@hugeicons/core-free-icons";
+import { UpdateProjectSettingsCommand } from "@/commands/project";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -34,7 +37,10 @@ export function PreviewToolbar({
 	return (
 		<div className="grid grid-cols-[1fr_auto_1fr] items-center pb-3 pt-5 px-5">
 			<TimecodeDisplay />
-			<PlayPauseButton />
+			<div className="justify-self-center flex items-center gap-1">
+				<PlayPauseButton />
+				<LoopToggleButton />
+			</div>
 			<div className="justify-self-end flex items-center gap-2.5">
 				<ZoomSelect />
 				<Separator orientation="vertical" className="h-4" />
@@ -141,6 +147,26 @@ function PlayPauseButton() {
 			onClick={() => invokeAction("toggle-play")}
 		>
 			<HugeiconsIcon icon={isPlaying ? PauseIcon : PlayIcon} />
+		</Button>
+	);
+}
+
+function LoopToggleButton() {
+	const loop = useEditor((e) => e.project.getActive()?.settings.loop === true);
+
+	return (
+		<Button
+			type="button"
+			variant={loop ? "secondary" : "text"}
+			size="icon"
+			aria-pressed={loop}
+			aria-label={loop ? "Disable loop playback" : "Enable loop playback"}
+			title={loop ? "Loop is on" : "Loop is off"}
+			onClick={() => {
+				new UpdateProjectSettingsCommand({ loop: !loop }).execute();
+			}}
+		>
+			<HugeiconsIcon icon={loop ? RepeatIcon : RepeatOffIcon} />
 		</Button>
 	);
 }

--- a/apps/web/src/project/types.ts
+++ b/apps/web/src/project/types.ts
@@ -33,6 +33,11 @@ export interface TProjectSettings {
 	lastCustomCanvasSize?: TCanvasSize | null;
 	originalCanvasSize?: TCanvasSize | null;
 	background: TBackground;
+	/**
+	 * When true, preview playback wraps back to the start of the timeline
+	 * instead of pausing once the playhead reaches the end. Defaults to false.
+	 */
+	loop?: boolean;
 }
 
 export interface TTimelineViewState {


### PR DESCRIPTION
## Summary

Adds a loop toggle button next to the play/pause control in the preview toolbar. When enabled, preview playback wraps back to the start of the timeline instead of pausing once the playhead reaches the end. The state is persisted as a per-project setting (\`TProjectSettings.loop\`) so it survives reloads and is remembered per project. Defaults to off.

## What changed

- **\`TProjectSettings.loop?: boolean\`** — optional field, undefined/false means current behaviour (pause at end).
- **\`LoopToggleButton\`** — new icon button in the preview toolbar, placed next to the play/pause control. Toggles through \`UpdateProjectSettingsCommand\`, so the action is undoable / redoable.
- **\`PlaybackManager.updateTime\`** — when the playhead reaches the end and \`settings.loop\` is true, the manager resets its internal start times to zero, fires a seek event, and queues another animation frame instead of pausing. The audio manager reacts to the seek through its existing \`onSeek\` listener, so audio restarts in sync.

## Test plan

- [x] Manual: timeline > 0 duration, toggle loop on, play → playhead returns to start and continues looping until manually paused; audio restarts in sync each cycle.
- [x] Manual: with loop off (default), playback still pauses at the end as before.
- [x] Manual: toggle state survives a reload (persisted in the saved project).
- [x] TypeScript: no new errors introduced.

## Notes

- Stacked on top of #794 locally for development; this PR's diff against \`main\` only contains the loop changes and applies cleanly on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a loop toggle button in the preview toolbar for quick playback control.
  * Preview playback can now loop: when enabled, playback wraps to the timeline start instead of pausing at the end.
  * Introduced a project-level loop setting (off by default) to enable/disable preview looping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenCut-app/OpenCut/pull/795?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->