### PR TITLE
feat(timeline): tint video and image clips by element type

### DIFF
--- a/apps/web/src/timeline/components/__tests__/theme.test.ts
+++ b/apps/web/src/timeline/components/__tests__/theme.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import {
+	getTimelineElementClassName,
+	getTimelineElementClassNameForElement,
+	TIMELINE_ELEMENT_THEME,
+	TIMELINE_TRACK_THEME,
+} from "../theme";
+
+describe("getTimelineElementClassName", () => {
+	test("returns the configured class for each track type", () => {
+		expect(getTimelineElementClassName({ type: "audio" })).toBe(
+			TIMELINE_TRACK_THEME.audio.elementClassName.trim(),
+		);
+		expect(getTimelineElementClassName({ type: "text" })).toBe(
+			TIMELINE_TRACK_THEME.text.elementClassName.trim(),
+		);
+	});
+});
+
+describe("getTimelineElementClassNameForElement", () => {
+	test("uses the element-level theme when one is defined", () => {
+		expect(
+			getTimelineElementClassNameForElement({
+				elementType: "video",
+				trackType: "video",
+			}),
+		).toBe(TIMELINE_ELEMENT_THEME.video?.elementClassName.trim());
+	});
+
+	test("distinguishes video and image even though they share the video track", () => {
+		const videoClass = getTimelineElementClassNameForElement({
+			elementType: "video",
+			trackType: "video",
+		});
+		const imageClass = getTimelineElementClassNameForElement({
+			elementType: "image",
+			trackType: "video",
+		});
+		expect(videoClass).not.toBe(imageClass);
+	});
+
+	test("falls back to the track-level theme when an element type has no override", () => {
+		expect(
+			getTimelineElementClassNameForElement({
+				elementType: "audio",
+				trackType: "audio",
+			}),
+		).toBe(TIMELINE_TRACK_THEME.audio.elementClassName.trim());
+
+		expect(
+			getTimelineElementClassNameForElement({
+				elementType: "text",
+				trackType: "text",
+			}),
+		).toBe(TIMELINE_TRACK_THEME.text.elementClassName.trim());
+
+		expect(
+			getTimelineElementClassNameForElement({
+				elementType: "sticker",
+				trackType: "graphic",
+			}),
+		).toBe(TIMELINE_TRACK_THEME.graphic.elementClassName.trim());
+	});
+});

--- a/apps/web/src/timeline/components/theme.ts
+++ b/apps/web/src/timeline/components/theme.ts
@@ -1,4 +1,4 @@
-import type { TrackType } from "@/timeline";
+import type { ElementType, TrackType } from "@/timeline";
 
 export const TIMELINE_AUDIO_WAVEFORM_COLOR = "rgba(255, 255, 255, 0.7)";
 
@@ -19,6 +19,22 @@ export const TIMELINE_TRACK_THEME: Record<
 	effect: { elementClassName: "bg-[#5d93ba]" },
 } as const;
 
+/**
+ * Per-element-type background tint applied to clips on the timeline.
+ *
+ * Falls back to the track-level theme when an element type has no
+ * dedicated entry. Used so that clips on the same track (e.g. video
+ * and image, which both live on the "video" track) can still be
+ * visually distinguished from each other and from the timeline
+ * background.
+ */
+export const TIMELINE_ELEMENT_THEME: Partial<
+	Record<ElementType, { elementClassName: string }>
+> = {
+	video: { elementClassName: "bg-sky-500/20" },
+	image: { elementClassName: "bg-amber-500/20" },
+} as const;
+
 export const SELECTED_TRACK_ROW_CLASS = "bg-accent/50";
 export const DEFAULT_TIMELINE_BOOKMARK_COLOR = "#009dff";
 
@@ -28,4 +44,18 @@ export function getTimelineElementClassName({
 	type: TrackType;
 }): string {
 	return TIMELINE_TRACK_THEME[type].elementClassName.trim();
+}
+
+export function getTimelineElementClassNameForElement({
+	elementType,
+	trackType,
+}: {
+	elementType: ElementType;
+	trackType: TrackType;
+}): string {
+	const elementTheme = TIMELINE_ELEMENT_THEME[elementType];
+	if (elementTheme) {
+		return elementTheme.elementClassName.trim();
+	}
+	return TIMELINE_TRACK_THEME[trackType].elementClassName.trim();
 }

--- a/apps/web/src/timeline/components/timeline-element.tsx
+++ b/apps/web/src/timeline/components/timeline-element.tsx
@@ -23,7 +23,11 @@ import {
 	timelineTimeToSnappedPixels,
 } from "@/timeline";
 import { getTrackHeight } from "./track-layout";
-import { getTimelineElementClassName, TIMELINE_TRACK_THEME } from "./theme";
+import {
+	getTimelineElementClassName,
+	getTimelineElementClassNameForElement,
+	TIMELINE_TRACK_THEME,
+} from "./theme";
 import {
 	ContextMenu,
 	ContextMenuContent,
@@ -585,8 +589,9 @@ function ElementInner({
 						<div
 							className={cn(
 								"flex shrink-0 items-center overflow-hidden",
-								getTimelineElementClassName({
-									type: getTrackTypeForElementType({
+								getTimelineElementClassNameForElement({
+									elementType: element.type,
+									trackType: getTrackTypeForElementType({
 										elementType: element.type,
 									}),
 								}),


### PR DESCRIPTION
## Summary

Video clips on the timeline previously had a transparent background (\`TIMELINE_TRACK_THEME.video.elementClassName = \"transparent\"\`), so they blended into the timeline surface and were only visible once selected. Image clips share the same track type as video, so they had the exact same problem.

This PR adds a subtle per-element-type tint:

| element type | background |
|---|---|
| video | \`bg-sky-500/20\` (subtle sky / celeste) |
| image | \`bg-amber-500/20\` (subtle amber) |
| audio / text / sticker / graphic / effect | unchanged (existing track-level theme) |

## How

- Introduces \`TIMELINE_ELEMENT_THEME\`, a \`Partial<Record<ElementType, …>>\` map that lets specific element types override the track-level theme.
- Adds \`getTimelineElementClassNameForElement({ elementType, trackType })\` which prefers the element-level theme and falls back to \`TIMELINE_TRACK_THEME\` when no override exists.
- The single render site in \`timeline-element.tsx\` now calls the new helper, so the legacy \`getTimelineElementClassName\` is left intact for any other consumer (none exist today, but the surface stays stable).

The colour values are intentionally low-alpha so the selected-state and hover styling are still clearly the strongest visual signal on a clip.

## Test plan

- [x] Unit tests cover the element-level override, the track-level fallback, and that video and image now produce different class names. \`bun test ./apps/web/src/timeline/components/__tests__/theme.test.ts\` → 4 pass.
- [x] Manual: imported a video and an image into the same track. Both clips are now clearly visible against the timeline background and distinguishable from each other, while audio/text/sticker clips look identical to before.

## Notes

- Configurability (user-customisable colours or a per-project theme) is intentionally out of scope to keep this PR small. If maintainers want it, happy to follow up with a dedicated PR that turns the whole theme into a configurable surface, not just the two new entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timeline elements now support individual theme customization alongside track-level theming, with automatic fallback when element-specific theming is not configured.

* **Tests**
  * Added comprehensive test suite for timeline theme configuration and styling application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenCut-app/OpenCut/pull/796?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->