### PR TITLE
feat: add range selection functionality to element interaction

### DIFF
--- a/apps/web/src/timeline/controllers/element-interaction-controller.ts
+++ b/apps/web/src/timeline/controllers/element-interaction-controller.ts
@@ -55,6 +55,10 @@ export interface ElementSelectionApi {
 	getSelected: () => readonly ElementRef[];
 	isSelected: (ref: ElementRef) => boolean;
 	select: (ref: ElementRef) => void;
+	selectRange: (args: {
+		anchor?: ElementRef | null;
+		target: ElementRef;
+	}) => readonly ElementRef[];
 	handleClick: (args: ElementRef & { isMultiKey: boolean }) => void;
 	clearKeyframeSelection: () => void;
 }
@@ -295,6 +299,7 @@ export class ElementInteractionController {
 	// has already returned to idle, so the "was this a drag?" answer must
 	// outlive the session. Reset on the next mousedown.
 	private lastGestureWasDrag = false;
+	private elementSelectionAnchor: ElementRef | null = null;
 
 	private readonly subscribers = new Set<() => void>();
 	private readonly depsRef: ElementInteractionDepsRef;
@@ -372,13 +377,21 @@ export class ElementInteractionController {
 
 		const ref = { trackId: track.id, elementId: element.id };
 
-		if (event.metaKey || event.ctrlKey || event.shiftKey) {
+		let rangeSelection: readonly ElementRef[] | null = null;
+		if (event.shiftKey) {
+			rangeSelection = this.deps.selection.selectRange({
+				anchor: this.elementSelectionAnchor,
+				target: ref,
+			});
+		} else if (event.metaKey || event.ctrlKey) {
 			this.deps.selection.handleClick({ ...ref, isMultiKey: true });
 		}
 
-		const selectedElements = this.deps.selection.isSelected(ref)
-			? this.deps.selection.getSelected()
-			: [ref];
+		const selectedElements =
+			rangeSelection ??
+			(this.deps.selection.isSelected(ref)
+				? this.deps.selection.getSelected()
+				: [ref]);
 
 		this.session = {
 			kind: "pending",
@@ -423,9 +436,11 @@ export class ElementInteractionController {
 			this.deps.selection.getSelected().length > 1
 		) {
 			this.deps.selection.select(ref);
+			this.elementSelectionAnchor = ref;
 			return;
 		}
 
+		this.elementSelectionAnchor = ref;
 		this.deps.selection.clearKeyframeSelection();
 	};
 

--- a/apps/web/src/timeline/controllers/element-interaction-controller.ts
+++ b/apps/web/src/timeline/controllers/element-interaction-controller.ts
@@ -379,10 +379,18 @@ export class ElementInteractionController {
 
 		let rangeSelection: readonly ElementRef[] | null = null;
 		if (event.shiftKey) {
+			const anchor =
+				this.elementSelectionAnchor?.trackId === ref.trackId
+					? this.elementSelectionAnchor
+					: null;
 			rangeSelection = this.deps.selection.selectRange({
-				anchor: this.elementSelectionAnchor,
+				anchor: anchor ?? ref,
 				target: ref,
 			});
+
+			if (!anchor) {
+				this.elementSelectionAnchor = ref;
+			}
 		} else if (event.metaKey || event.ctrlKey) {
 			this.deps.selection.handleClick({ ...ref, isMultiKey: true });
 		}

--- a/apps/web/src/timeline/hooks/element/use-element-interaction.ts
+++ b/apps/web/src/timeline/hooks/element/use-element-interaction.ts
@@ -50,6 +50,7 @@ export function useElementInteraction({
 			getSelected: () => selection.selectedElements,
 			isSelected: selection.isElementSelected,
 			select: selection.selectElement,
+			selectRange: selection.selectElementRange,
 			handleClick: selection.handleElementClick,
 			clearKeyframeSelection: () => editor.selection.clearKeyframeSelection(),
 		},

--- a/apps/web/src/timeline/hooks/element/use-element-selection.ts
+++ b/apps/web/src/timeline/hooks/element/use-element-selection.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { useEditor } from "@/editor/use-editor";
+import { findTrackInSceneTracks } from "@/timeline/track-element-update";
 import type { ElementRef } from "@/timeline/types";
 
 export function useElementSelection() {
@@ -102,8 +103,8 @@ export function useElementSelection() {
 	);
 
 	/**
-	 * Selects every element between the anchor and target on the same timeline row.
-	 * Falls back to selecting only the target when no same-row anchor exists.
+	 * Handles Shift-click range selection. Selects all clips between the anchor
+	 * and target when both are on the same track; otherwise selects only target.
 	 */
 	const selectElementRange = useCallback(
 		({
@@ -113,58 +114,47 @@ export function useElementSelection() {
 			anchor?: ElementRef | null;
 			target: ElementRef;
 		}) => {
-			const tracks = editor.scenes.getActiveScene().tracks;
-			const track = [...tracks.overlay, tracks.main, ...tracks.audio].find(
-				(candidate) => candidate.id === target.trackId,
-			);
-			const rangeAnchor =
-				anchor?.trackId === target.trackId
-					? anchor
-					: selectedElements
-							.slice()
-							.reverse()
-							.find((element) => element.trackId === target.trackId);
-
-			if (!track || !rangeAnchor) {
-				const elements = [target];
+			const setSelection = (elements: ElementRef[]) => {
 				editor.selection.setSelectedElements({ elements });
 				return elements;
+			};
+
+			const track = findTrackInSceneTracks({
+				tracks: editor.scenes.getActiveScene().tracks,
+				trackId: target.trackId,
+			});
+			if (!track || anchor?.trackId !== target.trackId) {
+				return setSelection([target]);
 			}
 
 			const orderedElements = track.elements
 				.map((element, index) => ({ element, index }))
-				.sort((a, b) => {
-					if (a.element.startTime !== b.element.startTime) {
-						return a.element.startTime - b.element.startTime;
-					}
-					return a.index - b.index;
-				});
+				.sort((a, b) =>
+					a.element.startTime === b.element.startTime
+						? a.index - b.index
+						: a.element.startTime - b.element.startTime,
+				);
 			const anchorIndex = orderedElements.findIndex(
-				({ element }) => element.id === rangeAnchor.elementId,
+				({ element }) => element.id === anchor.elementId,
 			);
 			const targetIndex = orderedElements.findIndex(
 				({ element }) => element.id === target.elementId,
 			);
 
 			if (anchorIndex === -1 || targetIndex === -1) {
-				const elements = [target];
-				editor.selection.setSelectedElements({ elements });
-				return elements;
+				return setSelection([target]);
 			}
 
 			const start = Math.min(anchorIndex, targetIndex);
 			const end = Math.max(anchorIndex, targetIndex);
-			const elements = orderedElements
-				.slice(start, end + 1)
-				.map(({ element }) => ({
+			return setSelection(
+				orderedElements.slice(start, end + 1).map(({ element }) => ({
 					trackId: target.trackId,
 					elementId: element.id,
-				}));
-
-			editor.selection.setSelectedElements({ elements });
-			return elements;
+				})),
+			);
 		},
-		[selectedElements, editor],
+		[editor],
 	);
 
 	/**

--- a/apps/web/src/timeline/hooks/element/use-element-selection.ts
+++ b/apps/web/src/timeline/hooks/element/use-element-selection.ts
@@ -101,6 +101,10 @@ export function useElementSelection() {
 		[selectedElements, editor],
 	);
 
+	/**
+	 * Selects every element between the anchor and target on the same timeline row.
+	 * Falls back to selecting only the target when no same-row anchor exists.
+	 */
 	const selectElementRange = useCallback(
 		({
 			anchor,

--- a/apps/web/src/timeline/hooks/element/use-element-selection.ts
+++ b/apps/web/src/timeline/hooks/element/use-element-selection.ts
@@ -101,6 +101,67 @@ export function useElementSelection() {
 		[selectedElements, editor],
 	);
 
+	const selectElementRange = useCallback(
+		({
+			anchor,
+			target,
+		}: {
+			anchor?: ElementRef | null;
+			target: ElementRef;
+		}) => {
+			const tracks = editor.scenes.getActiveScene().tracks;
+			const track = [...tracks.overlay, tracks.main, ...tracks.audio].find(
+				(candidate) => candidate.id === target.trackId,
+			);
+			const rangeAnchor =
+				anchor?.trackId === target.trackId
+					? anchor
+					: selectedElements
+							.slice()
+							.reverse()
+							.find((element) => element.trackId === target.trackId);
+
+			if (!track || !rangeAnchor) {
+				const elements = [target];
+				editor.selection.setSelectedElements({ elements });
+				return elements;
+			}
+
+			const orderedElements = track.elements
+				.map((element, index) => ({ element, index }))
+				.sort((a, b) => {
+					if (a.element.startTime !== b.element.startTime) {
+						return a.element.startTime - b.element.startTime;
+					}
+					return a.index - b.index;
+				});
+			const anchorIndex = orderedElements.findIndex(
+				({ element }) => element.id === rangeAnchor.elementId,
+			);
+			const targetIndex = orderedElements.findIndex(
+				({ element }) => element.id === target.elementId,
+			);
+
+			if (anchorIndex === -1 || targetIndex === -1) {
+				const elements = [target];
+				editor.selection.setSelectedElements({ elements });
+				return elements;
+			}
+
+			const start = Math.min(anchorIndex, targetIndex);
+			const end = Math.max(anchorIndex, targetIndex);
+			const elements = orderedElements
+				.slice(start, end + 1)
+				.map(({ element }) => ({
+					trackId: target.trackId,
+					elementId: element.id,
+				}));
+
+			editor.selection.setSelectedElements({ elements });
+			return elements;
+		},
+		[selectedElements, editor],
+	);
 
 	/**
 	 * Handles click interaction on an element.
@@ -128,6 +189,7 @@ export function useElementSelection() {
 		selectElement,
 		setElementSelection,
 		mergeElementsIntoSelection,
+		selectElementRange,
 		addElementToSelection,
 		removeElementFromSelection,
 		toggleElementSelection,


### PR DESCRIPTION
Closes #801 

Adds Shift-click range selection for timeline clips on the same row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shift-range selection: hold Shift and click to select a contiguous range of timeline elements between an anchor and a target.
  * Anchor-aware selection: range selection uses an anchor when on the same track; otherwise selection falls back to the clicked element, and editor selection is updated for each element in the chosen range.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenCut-app/OpenCut/pull/800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->