### PR TITLE
fix: restore Docker production build (resolves #782)

### DIFF
--- a/apps/web/src/actions/definitions.ts
+++ b/apps/web/src/actions/definitions.ts
@@ -208,3 +208,19 @@ export function getDefaultShortcuts(): Map<
 
 	return shortcuts;
 }
+
+const ACTION_SET: ReadonlySet<string> = new Set(Object.keys(ACTIONS));
+// IMPORTANT: This Set must stay in sync with entries in `TActionArgsMap` (./types.ts)
+// whose value type does not include `undefined`. If you add a new required-args action
+// to TActionArgsMap, add its ID here too — otherwise `isActionWithOptionalArgs` will
+// return true at runtime for an action that actually requires arguments.
+const REQUIRED_ARGS_ACTIONS: ReadonlySet<string> = new Set<string>([
+	"remove-media-asset",
+	"remove-media-assets",
+]);
+
+export function isActionWithOptionalArgs(
+	value: string,
+): value is TActionWithOptionalArgs {
+	return ACTION_SET.has(value) && !REQUIRED_ARGS_ACTIONS.has(value);
+}

--- a/apps/web/src/actions/keybinding.ts
+++ b/apps/web/src/actions/keybinding.ts
@@ -38,6 +38,25 @@ export type SingleCharacterShortcutKey = `${Key}`;
 
 export type ShortcutKey = ModifierBasedShortcutKey | SingleCharacterShortcutKey;
 
+const MODIFIER_SET: ReadonlySet<string> = new Set<string>([
+	"ctrl",
+	"alt",
+	"shift",
+	"ctrl+shift",
+	"alt+shift",
+	"ctrl+alt",
+	"ctrl+alt+shift",
+]);
+
+export function isShortcutKey(value: string): value is ShortcutKey {
+	if (isKey(value)) return true;
+	const lastPlus = value.lastIndexOf("+");
+	if (lastPlus === -1) return false;
+	return (
+		MODIFIER_SET.has(value.slice(0, lastPlus)) && isKey(value.slice(lastPlus + 1))
+	);
+}
+
 export type KeybindingConfig = {
 	[key in ShortcutKey]?: TActionWithOptionalArgs;
 };

--- a/apps/web/src/services/storage/migrations/runner.ts
+++ b/apps/web/src/services/storage/migrations/runner.ts
@@ -38,11 +38,11 @@ export async function runStorageMigrations({
 		hasCleanedUpMetaDb = true;
 	}
 
-	const projectsAdapter = new IndexedDBAdapter<ProjectRecord>(
-		"video-editor-projects",
-		"projects",
-		1,
-	);
+	const projectsAdapter = new IndexedDBAdapter<ProjectRecord>({
+		dbName: "video-editor-projects",
+		storeName: "projects",
+		version: 1,
+	});
 
 	const projects = await projectsAdapter.getAll();
 
@@ -95,7 +95,7 @@ export async function runStorageMigrations({
 				break;
 			}
 
-			await projectsAdapter.set(projectId, result.project);
+			await projectsAdapter.set({ key: projectId, value: result.project });
 			migratedCount++;
 			currentVersion = migration.to;
 			projectRecord = result.project;

--- a/apps/web/src/services/storage/migrations/v1-to-v2.ts
+++ b/apps/web/src/services/storage/migrations/v1-to-v2.ts
@@ -121,20 +121,20 @@ async function loadLegacyTracksForScene({
 	const sceneDbName = `video-editor-timelines-${projectId}-${sceneId}`;
 	const projectDbName = `video-editor-timelines-${projectId}`;
 
-	const adapter = new IndexedDBAdapter<LegacyTimelineData>(
-		sceneDbName,
-		"timeline",
-		1,
-	);
+	const adapter = new IndexedDBAdapter<LegacyTimelineData>({
+		dbName: sceneDbName,
+		storeName: "timeline",
+		version: 1,
+	});
 
 	let data = await adapter.get("timeline");
 
 	if (!data && isMain) {
-		const projectAdapter = new IndexedDBAdapter<LegacyTimelineData>(
-			projectDbName,
-			"timeline",
-			1,
-		);
+		const projectAdapter = new IndexedDBAdapter<LegacyTimelineData>({
+			dbName: projectDbName,
+			storeName: "timeline",
+			version: 1,
+		});
 		data = await projectAdapter.get("timeline");
 	}
 
@@ -157,11 +157,11 @@ async function loadMediaTypesById({
 		return {};
 	}
 
-	const mediaMetadataAdapter = new IndexedDBAdapter<MediaAssetData>(
-		`video-editor-media-${projectId}`,
-		"media-metadata",
-		1,
-	);
+	const mediaMetadataAdapter = new IndexedDBAdapter<MediaAssetData>({
+		dbName: `video-editor-media-${projectId}`,
+		storeName: "media-metadata",
+		version: 1,
+	});
 
 	const mediaEntries = await Promise.all(
 		mediaIds.map(async (mediaId) => {

--- a/apps/web/src/stickers/providers/index.ts
+++ b/apps/web/src/stickers/providers/index.ts
@@ -19,6 +19,6 @@ export function registerDefaultStickerProviders({
 		if (stickersRegistry.has(provider.id)) {
 			continue;
 		}
-		stickersRegistry.register(provider.id, provider);
+		stickersRegistry.register({ key: provider.id, definition: provider });
 	}
 }


### PR DESCRIPTION
## Summary

Resolves #782. Restores production build by applying the 5 fixes that the issue author documented in detail.

## Changes

1. `actions/keybinding.ts` — Add `isShortcutKey` type guard (imported by `keybindings/persistence.ts`)
2. `actions/definitions.ts` — Add `isActionWithOptionalArgs` runtime guard (imported by `keybindings/persistence.ts`)
3. `services/storage/migrations/runner.ts` — Migrate IndexedDBAdapter constructor + .set() calls to object args
4. `services/storage/migrations/v1-to-v2.ts` — Migrate 3 IndexedDBAdapter constructor call sites to object args
5. `stickers/providers/index.ts` — Migrate register() call to object args

All five are mechanical fixes from a stale positional-arg refactor; no logic changes.

## Verification

- `bunx tsc --noEmit` — the 5 errors from #782 are gone (other pre-existing errors unrelated to this PR remain)
- `bun run build` — TypeScript compiled successfully (`✓ Compiled successfully`); build halts at env-var validation (ZodError for DATABASE_URL etc.) which requires secrets not present in a local clone — this is pre-existing and unrelated to our changes
- `bun run lint` — 0 errors in the 5 modified files (pre-existing lint errors in other files remain)

## Test Plan

- [x] Reproduced original build failure on main
- [x] Applied fixes
- [x] Verified Next.js TypeScript compilation succeeds
- [x] Lint clean on modified files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for keyboard shortcuts to accept only supported modifier combinations.
  * Enhanced action classification to correctly distinguish actions with optional vs required arguments.

* **Improvements**
  * Refined storage migration flow for more consistent project persistence during upgrades.
  * Standardized registration of sticker providers for more predictable provider handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenCut-app/OpenCut/pull/803?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->