### PR TITLE
feat: add projectType metadata field (standard | shorts)

### DIFF
--- a/apps/web/src/core/managers/project-manager.ts
+++ b/apps/web/src/core/managers/project-manager.ts
@@ -5,6 +5,7 @@ import type {
 	TProjectSortKey,
 	TProjectSortOption,
 	TProjectSettings,
+	TProjectType,
 	TTimelineViewState,
 } from "@/project/types";
 import type { ExportOptions, ExportResult, ExportState } from "@/export";
@@ -79,7 +80,13 @@ export class ProjectManager {
 		await this.storageMigrationPromise;
 	}
 
-	async createNewProject({ name }: { name: string }): Promise<string> {
+	async createNewProject({
+		name,
+		projectType,
+	}: {
+		name: string;
+		projectType?: TProjectType;
+	}): Promise<string> {
 		const mainScene = buildDefaultScene({ name: "Main scene", isMain: true });
 		const newProject: TProject = {
 			metadata: {
@@ -88,6 +95,7 @@ export class ProjectManager {
 				duration: getProjectDurationFromScenes({ scenes: [mainScene] }),
 				createdAt: new Date(),
 				updatedAt: new Date(),
+				projectType: projectType ?? "standard",
 			},
 			scenes: [mainScene],
 			currentSceneId: mainScene.id,

--- a/apps/web/src/project/__tests__/project-type.test.ts
+++ b/apps/web/src/project/__tests__/project-type.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { PROJECT_TYPES, type TProjectType } from "@/project/types";
+
+describe("PROJECT_TYPES", () => {
+	test("contains standard and shorts", () => {
+		expect(PROJECT_TYPES).toContain("standard");
+		expect(PROJECT_TYPES).toContain("shorts");
+	});
+
+	test("project metadata uses 'standard' when projectType is undefined", () => {
+		function buildMetadataProjectType(input?: TProjectType): TProjectType {
+			return input ?? "standard";
+		}
+		expect(buildMetadataProjectType(undefined)).toBe("standard");
+		expect(buildMetadataProjectType("shorts")).toBe("shorts");
+		expect(buildMetadataProjectType("standard")).toBe("standard");
+	});
+
+	test("PROJECT_TYPES is stable in declared order", () => {
+		expect([...PROJECT_TYPES]).toEqual(["standard", "shorts"]);
+	});
+});

--- a/apps/web/src/project/types.ts
+++ b/apps/web/src/project/types.ts
@@ -2,6 +2,15 @@ import type { FrameRate } from "opencut-wasm";
 import type { TScene } from "@/timeline/types";
 import type { MediaTime } from "@/wasm";
 
+export const PROJECT_TYPES = ["standard", "shorts"] as const;
+/**
+ * Project intent. "shorts" indicates a vertical 9:16 short-form project
+ * (e.g. YouTube Shorts) — drives preset pickers, export defaults, and
+ * vertical-safe text positioning. "standard" covers landscape, square,
+ * and other non-Shorts aspect ratios.
+ */
+export type TProjectType = (typeof PROJECT_TYPES)[number];
+
 export type TBackground =
 	| {
 			type: "color";
@@ -24,6 +33,13 @@ export interface TProjectMetadata {
 	duration: MediaTime;
 	createdAt: Date;
 	updatedAt: Date;
+	/**
+	 * Discriminator for project intent. Optional for back-compat — undefined on
+	 * projects created before this field existed; consumers MUST treat undefined
+	 * as "standard" (e.g. `projectType ?? "standard"`). New projects always set
+	 * this explicitly via ProjectManager.createNewProject.
+	 */
+	projectType?: TProjectType;
 }
 
 export interface TProjectSettings {


### PR DESCRIPTION
## Summary

Adds an optional discriminator field \`projectType\` to \`TProjectMetadata\`. This is foundational for upcoming Shorts-flavored features (9:16 preset, YouTube Shorts export preset, vertical-safe text positioning) that need to branch on user intent rather than infer it from canvas dimensions.

## Changes

- \`project/types.ts\` — Add \`PROJECT_TYPES\` const + \`TProjectType\` type. Add optional \`projectType\` field to \`TProjectMetadata\`.
- \`core/managers/project-manager.ts\` — \`createNewProject\` accepts optional \`projectType\`, defaults to \`"standard"\`.
- \`project/__tests__/project-type.test.ts\` — Type invariants.

Field is optional → existing stored projects in IndexedDB load unchanged.

## Why Optional

No storage migration needed. Code paths that branch on type use \`?? "standard"\`.

## Test Plan

- [x] \`bun test apps/web/src/project/__tests__/project-type.test.ts\` passes (3 tests)
- [x] \`bunx tsc --noEmit\` produces no new errors from this change
- [x] Lint clean for modified files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projects now support types ("standard" and "shorts").
  * Project creation accepts an optional project type, defaulting to "standard" when omitted.

* **Tests**
  * Added test coverage validating project types, defaulting behavior, and declared type order.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenCut-app/OpenCut/pull/804?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->