### PR TITLE
feat: add named canvas presets including YouTube Shorts 9:16

### DIFF
--- a/apps/web/src/canvas/__tests__/sizes.test.ts
+++ b/apps/web/src/canvas/__tests__/sizes.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import {
+	DEFAULT_CANVAS_PRESETS,
+	DEFAULT_CANVAS_SIZE,
+	NAMED_CANVAS_PRESETS,
+	SHORTS_CANVAS_PRESET,
+} from "@/canvas/sizes";
+
+describe("NAMED_CANVAS_PRESETS", () => {
+	test("has the four canonical presets in declared order", () => {
+		const ids = NAMED_CANVAS_PRESETS.map((p) => p.id);
+		expect(ids).toEqual([
+			"landscape-1080p",
+			"shorts-1080x1920",
+			"square-1080",
+			"landscape-1440",
+		]);
+	});
+
+	test("every preset has consistent shape", () => {
+		for (const preset of NAMED_CANVAS_PRESETS) {
+			expect(preset.id.length).toBeGreaterThan(0);
+			expect(preset.label.length).toBeGreaterThan(0);
+			expect(preset.size.width).toBeGreaterThan(0);
+			expect(preset.size.height).toBeGreaterThan(0);
+			expect(preset.aspectRatio).toMatch(/^\d+:\d+$/);
+		}
+	});
+});
+
+describe("SHORTS_CANVAS_PRESET", () => {
+	test("is 1080x1920 vertical 9:16", () => {
+		expect(SHORTS_CANVAS_PRESET.size).toEqual({ width: 1080, height: 1920 });
+		expect(SHORTS_CANVAS_PRESET.aspectRatio).toBe("9:16");
+		expect(SHORTS_CANVAS_PRESET.projectType).toBe("shorts");
+	});
+});
+
+describe("DEFAULT_CANVAS_PRESETS (back-compat)", () => {
+	test("derives from NAMED_CANVAS_PRESETS in order", () => {
+		expect(DEFAULT_CANVAS_PRESETS).toEqual(
+			NAMED_CANVAS_PRESETS.map((p) => p.size),
+		);
+	});
+
+	test("contains the Shorts preset 1080x1920", () => {
+		expect(DEFAULT_CANVAS_PRESETS).toContainEqual({
+			width: 1080,
+			height: 1920,
+		});
+	});
+});
+
+describe("DEFAULT_CANVAS_SIZE", () => {
+	test("remains 1920x1080 (landscape default)", () => {
+		expect(DEFAULT_CANVAS_SIZE).toEqual({ width: 1920, height: 1080 });
+	});
+});

--- a/apps/web/src/canvas/sizes.ts
+++ b/apps/web/src/canvas/sizes.ts
@@ -1,10 +1,63 @@
-import type { TCanvasSize } from "@/project/types";
+import type { TCanvasSize, TProjectType } from "@/project/types";
 
-export const DEFAULT_CANVAS_PRESETS: TCanvasSize[] = [
-	{ width: 1920, height: 1080 },
-	{ width: 1080, height: 1920 },
-	{ width: 1080, height: 1080 },
-	{ width: 1440, height: 1080 },
+/**
+ * A canvas preset bundles the raw size with display metadata (label,
+ * aspect ratio) and the project intent it implies. UIs should prefer
+ * NAMED_CANVAS_PRESETS when rendering preset pickers; consumers that
+ * only need the size array continue to use DEFAULT_CANVAS_PRESETS.
+ */
+export interface TCanvasPreset {
+	id: string;
+	label: string;
+	size: TCanvasSize;
+	aspectRatio: string;
+	projectType?: TProjectType;
+}
+
+export const NAMED_CANVAS_PRESETS: readonly TCanvasPreset[] = [
+	{
+		id: "landscape-1080p",
+		label: "Landscape 1920×1080",
+		size: { width: 1920, height: 1080 },
+		aspectRatio: "16:9",
+		projectType: "standard",
+	},
+	{
+		id: "shorts-1080x1920",
+		label: "YouTube Shorts (1080×1920)",
+		size: { width: 1080, height: 1920 },
+		aspectRatio: "9:16",
+		projectType: "shorts",
+	},
+	{
+		id: "square-1080",
+		label: "Square 1080×1080",
+		size: { width: 1080, height: 1080 },
+		aspectRatio: "1:1",
+		projectType: "standard",
+	},
+	{
+		id: "landscape-1440",
+		label: "Landscape 1440×1080",
+		size: { width: 1440, height: 1080 },
+		aspectRatio: "4:3",
+		projectType: "standard",
+	},
 ];
 
-export const DEFAULT_CANVAS_SIZE: TCanvasSize = { width: 1920, height: 1080 };
+/**
+ * Convenience reference to the YouTube Shorts preset.
+ */
+export const SHORTS_CANVAS_PRESET: TCanvasPreset = NAMED_CANVAS_PRESETS.find(
+	(p) => p.id === "shorts-1080x1920",
+)!;
+
+/**
+ * Back-compat: existing consumers (editor-store, etc.) read a bare
+ * TCanvasSize[]. Derived from NAMED_CANVAS_PRESETS to keep them in sync.
+ */
+export const DEFAULT_CANVAS_PRESETS: TCanvasSize[] = NAMED_CANVAS_PRESETS.map(
+	(p) => p.size,
+);
+
+export const DEFAULT_CANVAS_SIZE: TCanvasSize = NAMED_CANVAS_PRESETS[0].size;

--- a/apps/web/src/core/managers/project-manager.ts
+++ b/apps/web/src/core/managers/project-manager.ts
@@ -5,6 +5,7 @@ import type {
 	TProjectSortKey,
 	TProjectSortOption,
 	TProjectSettings,
+	TProjectType,
 	TTimelineViewState,
 } from "@/project/types";
 import type { ExportOptions, ExportResult, ExportState } from "@/export";
@@ -79,7 +80,13 @@ export class ProjectManager {
 		await this.storageMigrationPromise;
 	}
 
-	async createNewProject({ name }: { name: string }): Promise<string> {
+	async createNewProject({
+		name,
+		projectType,
+	}: {
+		name: string;
+		projectType?: TProjectType;
+	}): Promise<string> {
 		const mainScene = buildDefaultScene({ name: "Main scene", isMain: true });
 		const newProject: TProject = {
 			metadata: {
@@ -88,6 +95,7 @@ export class ProjectManager {
 				duration: getProjectDurationFromScenes({ scenes: [mainScene] }),
 				createdAt: new Date(),
 				updatedAt: new Date(),
+				projectType: projectType ?? "standard",
 			},
 			scenes: [mainScene],
 			currentSceneId: mainScene.id,

--- a/apps/web/src/project/__tests__/project-type.test.ts
+++ b/apps/web/src/project/__tests__/project-type.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { PROJECT_TYPES, type TProjectType } from "@/project/types";
+
+describe("PROJECT_TYPES", () => {
+	test("contains standard and shorts", () => {
+		expect(PROJECT_TYPES).toContain("standard");
+		expect(PROJECT_TYPES).toContain("shorts");
+	});
+
+	test("project metadata uses 'standard' when projectType is undefined", () => {
+		function buildMetadataProjectType(input?: TProjectType): TProjectType {
+			return input ?? "standard";
+		}
+		expect(buildMetadataProjectType(undefined)).toBe("standard");
+		expect(buildMetadataProjectType("shorts")).toBe("shorts");
+		expect(buildMetadataProjectType("standard")).toBe("standard");
+	});
+
+	test("PROJECT_TYPES is stable in declared order", () => {
+		expect([...PROJECT_TYPES]).toEqual(["standard", "shorts"]);
+	});
+});

--- a/apps/web/src/project/types.ts
+++ b/apps/web/src/project/types.ts
@@ -2,6 +2,15 @@ import type { FrameRate } from "opencut-wasm";
 import type { TScene } from "@/timeline/types";
 import type { MediaTime } from "@/wasm";
 
+export const PROJECT_TYPES = ["standard", "shorts"] as const;
+/**
+ * Project intent. "shorts" indicates a vertical 9:16 short-form project
+ * (e.g. YouTube Shorts) — drives preset pickers, export defaults, and
+ * vertical-safe text positioning. "standard" covers landscape, square,
+ * and other non-Shorts aspect ratios.
+ */
+export type TProjectType = (typeof PROJECT_TYPES)[number];
+
 export type TBackground =
 	| {
 			type: "color";
@@ -24,6 +33,13 @@ export interface TProjectMetadata {
 	duration: MediaTime;
 	createdAt: Date;
 	updatedAt: Date;
+	/**
+	 * Discriminator for project intent. Optional for back-compat — undefined on
+	 * projects created before this field existed; consumers MUST treat undefined
+	 * as "standard" (e.g. `projectType ?? "standard"`). New projects always set
+	 * this explicitly via ProjectManager.createNewProject.
+	 */
+	projectType?: TProjectType;
 }
 
 export interface TProjectSettings {


### PR DESCRIPTION
## Summary

Currently `DEFAULT_CANVAS_PRESETS` is a bare `TCanvasSize[]` — UIs have no name to render and no way to know an entry's intent (e.g. "this is the Shorts preset"). This PR adds a parallel `NAMED_CANVAS_PRESETS` with id/label/aspectRatio/projectType metadata, including a dedicated `SHORTS_CANVAS_PRESET` for YouTube Shorts.

## Changes

- `canvas/sizes.ts` — Introduce `NAMED_CANVAS_PRESETS` and `TCanvasPreset` type
- `canvas/sizes.ts` — `DEFAULT_CANVAS_PRESETS` is now derived from `NAMED_CANVAS_PRESETS.map(p => p.size)` so existing consumers (`editor-store.ts`) are unaffected
- `canvas/sizes.ts` — `SHORTS_CANVAS_PRESET` exposed for direct reference
- `canvas/__tests__/sizes.test.ts` — Coverage for shape, ordering, back-compat

## Why Two Exports

`DEFAULT_CANVAS_PRESETS` (`TCanvasSize[]`) is preserved because `editor-store.ts:17` consumes it directly. Migrating that call site is out of scope for this PR — UI changes to render labels are a separate concern.

## Depends On

#804 (the `projectType` field PR) — `TCanvasPreset.projectType` references `TProjectType`. The base of this branch is `feat/project-type-field`, so the commit from #804 is included in this PR. Once #804 merges to main, this PR can rebase onto main.

## Test Plan

- [x] `bun test apps/web/src/canvas/__tests__/sizes.test.ts` — 6 tests pass
- [x] `bunx tsc --noEmit` — no new errors
- [x] Lint clean for modified files
- [x] Existing `editor-store.ts:17` (which reads `DEFAULT_CANVAS_PRESETS`) compiles unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project types: Users can now create projects as "standard" or "shorts"
  * Shorts projects optimized for vertical video (1080×1920, 9:16 aspect ratio)
  * Enhanced canvas preset system with improved organization and metadata

* **Tests**
  * Added comprehensive test coverage for canvas preset definitions and project type configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenCut-app/OpenCut/pull/805?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->