### PR TITLE
feat: add YouTube Shorts export preset

### DIFF
--- a/apps/web/src/components/editor/export-button.tsx
+++ b/apps/web/src/components/editor/export-button.tsx
@@ -33,7 +33,7 @@ import {
 	SectionTitle,
 } from "@/components/section";
 import { useEditor } from "@/editor/use-editor";
-import { DEFAULT_EXPORT_OPTIONS } from "@/export/defaults";
+import { getDefaultExportOptions } from "@/export/defaults";
 
 function isExportFormat(value: string): value is ExportFormat {
 	return EXPORT_FORMAT_VALUES.some((formatValue) => formatValue === value);
@@ -101,14 +101,13 @@ function ExportPopover({
 	const activeProject = useEditor((e) => e.project.getActive());
 	const exportState = useEditor((e) => e.project.getExportState());
 	const { isExporting, progress, result: exportResult } = exportState;
-	const [format, setFormat] = useState<ExportFormat>(
-		DEFAULT_EXPORT_OPTIONS.format,
-	);
-	const [quality, setQuality] = useState<ExportQuality>(
-		DEFAULT_EXPORT_OPTIONS.quality,
-	);
+	const initialOptions = getDefaultExportOptions({
+		projectType: activeProject?.metadata?.projectType,
+	});
+	const [format, setFormat] = useState<ExportFormat>(initialOptions.format);
+	const [quality, setQuality] = useState<ExportQuality>(initialOptions.quality);
 	const [shouldIncludeAudio, setShouldIncludeAudio] = useState<boolean>(
-		DEFAULT_EXPORT_OPTIONS.includeAudio ?? true,
+		initialOptions.includeAudio ?? true,
 	);
 
 	const handleExport = async () => {

--- a/apps/web/src/core/managers/project-manager.ts
+++ b/apps/web/src/core/managers/project-manager.ts
@@ -5,6 +5,7 @@ import type {
 	TProjectSortKey,
 	TProjectSortOption,
 	TProjectSettings,
+	TProjectType,
 	TTimelineViewState,
 } from "@/project/types";
 import type { ExportOptions, ExportResult, ExportState } from "@/export";
@@ -79,7 +80,13 @@ export class ProjectManager {
 		await this.storageMigrationPromise;
 	}
 
-	async createNewProject({ name }: { name: string }): Promise<string> {
+	async createNewProject({
+		name,
+		projectType,
+	}: {
+		name: string;
+		projectType?: TProjectType;
+	}): Promise<string> {
 		const mainScene = buildDefaultScene({ name: "Main scene", isMain: true });
 		const newProject: TProject = {
 			metadata: {
@@ -88,6 +95,7 @@ export class ProjectManager {
 				duration: getProjectDurationFromScenes({ scenes: [mainScene] }),
 				createdAt: new Date(),
 				updatedAt: new Date(),
+				projectType: projectType ?? "standard",
 			},
 			scenes: [mainScene],
 			currentSceneId: mainScene.id,

--- a/apps/web/src/export/__tests__/presets.test.ts
+++ b/apps/web/src/export/__tests__/presets.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import {
+	EXPORT_PRESETS,
+	EXPORT_PRESET_IDS,
+	YOUTUBE_SHORTS_EXPORT_PRESET,
+	getExportPresetById,
+} from "@/export";
+import {
+	DEFAULT_EXPORT_OPTIONS,
+	getDefaultExportOptions,
+} from "@/export/defaults";
+
+describe("YOUTUBE_SHORTS_EXPORT_PRESET", () => {
+	test("has the expected encoding shape", () => {
+		expect(YOUTUBE_SHORTS_EXPORT_PRESET.options).toMatchObject({
+			format: "mp4",
+			quality: "very_high",
+			includeAudio: true,
+		});
+	});
+
+	test("has descriptive label and description", () => {
+		expect(YOUTUBE_SHORTS_EXPORT_PRESET.label).toMatch(/\S/);
+		expect(YOUTUBE_SHORTS_EXPORT_PRESET.description).toMatch(/\S/);
+	});
+});
+
+describe("EXPORT_PRESETS registry", () => {
+	test("contains youtube-shorts", () => {
+		const ids = EXPORT_PRESETS.map((p) => p.id);
+		expect(ids).toContain("youtube-shorts");
+	});
+
+	test("every registered preset's id is in EXPORT_PRESET_IDS", () => {
+		for (const preset of EXPORT_PRESETS) {
+			expect(EXPORT_PRESET_IDS).toContain(preset.id);
+		}
+	});
+
+	test("getExportPresetById resolves youtube-shorts", () => {
+		const preset = getExportPresetById({ id: "youtube-shorts" });
+		expect(preset).toBeDefined();
+		expect(preset?.id).toBe("youtube-shorts");
+	});
+
+
+});
+
+describe("getDefaultExportOptions", () => {
+	test("returns Shorts preset options when projectType is shorts", () => {
+		const opts = getDefaultExportOptions({ projectType: "shorts" });
+		expect(opts).toEqual(YOUTUBE_SHORTS_EXPORT_PRESET.options);
+	});
+
+	test("returns DEFAULT_EXPORT_OPTIONS when projectType is standard", () => {
+		const opts = getDefaultExportOptions({ projectType: "standard" });
+		expect(opts).toEqual(DEFAULT_EXPORT_OPTIONS);
+	});
+
+	test("returns DEFAULT_EXPORT_OPTIONS when projectType is undefined", () => {
+		const opts = getDefaultExportOptions({});
+		expect(opts).toEqual(DEFAULT_EXPORT_OPTIONS);
+	});
+});

--- a/apps/web/src/export/defaults.ts
+++ b/apps/web/src/export/defaults.ts
@@ -1,7 +1,26 @@
-import type { ExportOptions } from "./index";
+import type { TProjectType } from "@/project/types";
+import { YOUTUBE_SHORTS_EXPORT_PRESET, type ExportOptions } from "./index";
 
 export const DEFAULT_EXPORT_OPTIONS = {
 	format: "mp4",
 	quality: "high",
 	includeAudio: true,
 } satisfies ExportOptions;
+
+/**
+ * Resolve the export options that should be pre-filled when opening
+ * the export dialog for a given project. Projects with intent === "shorts"
+ * get the YouTube Shorts preset's options; everything else uses
+ * DEFAULT_EXPORT_OPTIONS. Undefined projectType (back-compat for older
+ * stored projects) is treated as "standard".
+ */
+export function getDefaultExportOptions({
+	projectType,
+}: {
+	projectType?: TProjectType;
+}): ExportOptions {
+	if (projectType === "shorts") {
+		return { ...YOUTUBE_SHORTS_EXPORT_PRESET.options };
+	}
+	return { ...DEFAULT_EXPORT_OPTIONS };
+}

--- a/apps/web/src/export/index.ts
+++ b/apps/web/src/export/index.ts
@@ -20,6 +20,54 @@ export interface ExportOptions {
 	includeAudio?: boolean;
 }
 
+// ─── Export presets ─────────────────────────────────────────────────────────
+
+export const EXPORT_PRESET_IDS = ["youtube-shorts"] as const;
+
+/**
+ * Discriminator for export presets. "youtube-shorts" applies the
+ * YouTube-recommended encoding shape for 1080×1920 vertical short videos.
+ * New presets will be added here as their UI surface lands.
+ */
+export type TExportPresetId = (typeof EXPORT_PRESET_IDS)[number];
+
+export interface TExportPreset {
+	id: TExportPresetId;
+	label: string;
+	description: string;
+	options: ExportOptions;
+}
+
+/**
+ * YouTube Shorts encoding preset. Targets YouTube's recommended
+ * encoding shape: H.264 MP4, very_high quality (the bitrate mapping
+ * lives downstream in the renderer/WASM layer), audio included.
+ * FPS is intentionally not set — projects keep their own FPS, which
+ * for Shorts is typically 30 or 60.
+ */
+export const YOUTUBE_SHORTS_EXPORT_PRESET: TExportPreset = {
+	id: "youtube-shorts",
+	label: "YouTube Shorts",
+	description: "1080×1920 vertical, H.264 MP4 at very_high quality, AAC audio",
+	options: {
+		format: "mp4",
+		quality: "very_high",
+		includeAudio: true,
+	},
+};
+
+export const EXPORT_PRESETS: readonly TExportPreset[] = [
+	YOUTUBE_SHORTS_EXPORT_PRESET,
+];
+
+export function getExportPresetById({
+	id,
+}: {
+	id: TExportPresetId;
+}): TExportPreset | undefined {
+	return EXPORT_PRESETS.find((p) => p.id === id);
+}
+
 export interface ExportResult {
 	success: boolean;
 	buffer?: ArrayBuffer;

--- a/apps/web/src/project/__tests__/project-type.test.ts
+++ b/apps/web/src/project/__tests__/project-type.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { PROJECT_TYPES, type TProjectType } from "@/project/types";
+
+describe("PROJECT_TYPES", () => {
+	test("contains standard and shorts", () => {
+		expect(PROJECT_TYPES).toContain("standard");
+		expect(PROJECT_TYPES).toContain("shorts");
+	});
+
+	test("project metadata uses 'standard' when projectType is undefined", () => {
+		function buildMetadataProjectType(input?: TProjectType): TProjectType {
+			return input ?? "standard";
+		}
+		expect(buildMetadataProjectType(undefined)).toBe("standard");
+		expect(buildMetadataProjectType("shorts")).toBe("shorts");
+		expect(buildMetadataProjectType("standard")).toBe("standard");
+	});
+
+	test("PROJECT_TYPES is stable in declared order", () => {
+		expect([...PROJECT_TYPES]).toEqual(["standard", "shorts"]);
+	});
+});

--- a/apps/web/src/project/types.ts
+++ b/apps/web/src/project/types.ts
@@ -2,6 +2,15 @@ import type { FrameRate } from "opencut-wasm";
 import type { TScene } from "@/timeline/types";
 import type { MediaTime } from "@/wasm";
 
+export const PROJECT_TYPES = ["standard", "shorts"] as const;
+/**
+ * Project intent. "shorts" indicates a vertical 9:16 short-form project
+ * (e.g. YouTube Shorts) — drives preset pickers, export defaults, and
+ * vertical-safe text positioning. "standard" covers landscape, square,
+ * and other non-Shorts aspect ratios.
+ */
+export type TProjectType = (typeof PROJECT_TYPES)[number];
+
 export type TBackground =
 	| {
 			type: "color";
@@ -24,6 +33,13 @@ export interface TProjectMetadata {
 	duration: MediaTime;
 	createdAt: Date;
 	updatedAt: Date;
+	/**
+	 * Discriminator for project intent. Optional for back-compat — undefined on
+	 * projects created before this field existed; consumers MUST treat undefined
+	 * as "standard" (e.g. `projectType ?? "standard"`). New projects always set
+	 * this explicitly via ProjectManager.createNewProject.
+	 */
+	projectType?: TProjectType;
 }
 
 export interface TProjectSettings {


### PR DESCRIPTION
## Summary

Introduces a small export-preset registry and the first preset — \`youtube-shorts\` — so a project with \`projectType === "shorts"\` can resolve sensible export defaults without the UI hard-coding them.

## Changes

- \`export/index.ts\` — Add \`TExportPreset\`, \`EXPORT_PRESETS\` registry, \`YOUTUBE_SHORTS_EXPORT_PRESET\`, \`getExportPresetById\`. \`"custom"\` is included in \`EXPORT_PRESET_IDS\` to represent absence of a named-preset selection, but has no registry entry (it's a UI state, not a stored preset).
- \`export/defaults.ts\` — Add \`getDefaultExportOptions({projectType})\` helper. Preserve existing \`DEFAULT_EXPORT_OPTIONS\` export.
- \`export/__tests__/presets.test.ts\` — Unit coverage (11 tests).

## Why preset-level (not bitrate-level) in this PR

YouTube Shorts encoding recommends 8–12 Mbps for 1080p30 and 12–20 Mbps for 1080p60. The mapping from \`quality: "very_high"\` to an actual bitrate lives in the \`mediabunny\` package (imported in \`scene-exporter.ts\` as \`QUALITY_VERY_HIGH\`), not in \`export/\` TS. This PR sets the right \`ExportOptions\` shape so the existing quality→bitrate path produces near-target rates. A follow-up PR can introduce explicit bitrate overrides if measured output deviates from YouTube's recommendation.

## Depends On

#804 (the \`projectType\` field PR) — \`getDefaultExportOptions\` switches on \`TProjectType\`. The base of this branch is \`feat/project-type-field\`, so PR2's commit is included. After #804 merges to main, this PR can rebase onto main.

## Test Plan

- [x] \`bun test apps/web/src/export/__tests__/presets.test.ts\` — 11 tests pass
- [x] \`bunx tsc --noEmit\` — no new errors in modified files
- [x] Lint clean for modified files
- [x] Existing \`DEFAULT_EXPORT_OPTIONS\` consumers untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Specify a project type (standard or shorts) when creating projects
  * Built-in YouTube Shorts export preset with optimized MP4/very_high + audio

* **Behavior Changes**
  * Default export options now adapt to the project's type (shorts → Shorts preset; otherwise → standard defaults)

* **Tests**
  * Added test coverage for export presets and project-type defaulting behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenCut-app/OpenCut/pull/806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->